### PR TITLE
Fix build

### DIFF
--- a/org.eclipse.images.renderer/pom.xml
+++ b/org.eclipse.images.renderer/pom.xml
@@ -22,7 +22,7 @@
 	<parent>
 		<artifactId>org.eclipse.images.parent</artifactId>
 		<groupId>eclipse.images</groupId>
-		<version>4.28.0-SNAPSHOT</version>
+		<version>4.29.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<packaging>maven-plugin</packaging>

--- a/org.eclipse.images/pom.xml
+++ b/org.eclipse.images/pom.xml
@@ -17,7 +17,7 @@
 	<parent>
 		<artifactId>org.eclipse.images.parent</artifactId>
 		<groupId>eclipse.images</groupId>
-		<version>4.28.0-SNAPSHOT</version>
+		<version>4.29.0-SNAPSHOT</version>
 		<relativePath>../</relativePath>
 	</parent>
 	<groupId>org.eclipse.images</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.eclipse</groupId>
     <artifactId>eclipse-platform-parent</artifactId>
-    <version>4.28.0-SNAPSHOT</version>
+    <version>4.29.0-SNAPSHOT</version>
     <relativePath>../eclipse-platform-parent</relativePath>
   </parent>
 


### PR DESCRIPTION
4.28.0 parent pom uses tycho snapshot so is no longer usable, switch to 4.29 that uses released 4.0.1 version