### PR TITLE
Target Java 17 in the renderer

### DIFF
--- a/org.eclipse.images.renderer/pom.xml
+++ b/org.eclipse.images.renderer/pom.xml
@@ -102,8 +102,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.11.0</version>
 				<configuration>
-					<source>11</source>
-					<target>11</target>
+					<source>17</source>
+					<target>17</target>
 				</configuration>
 			</plugin>
 			<plugin>


### PR DESCRIPTION
As Platform requires Java 17 now it makes no sense for these helper tools to keep old compatibility.