### PR TITLE
Find/Replace overlay: add icons for opening/closing the replace area.

### DIFF
--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.texteditor/full/obj16/close_replace.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.texteditor/full/obj16/close_replace.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="currentColor"
+   version="1.1"
+   id="svg7155"
+   sodipodi:docname="close_replace.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   inkscape:export-filename="close_replace@2x.png"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs7159" />
+  <sodipodi:namedview
+     id="namedview7157"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="64.1875"
+     inkscape:cx="4.7984421"
+     inkscape:cy="7.9922103"
+     inkscape:window-width="3440"
+     inkscape:window-height="1369"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg7155" />
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="M8.024 5.928l-4.357 4.357-.62-.618L7.716 5h.618L13 9.667l-.619.618-4.357-4.357z"
+     id="path7153"
+     style="fill:#797979;fill-opacity:1" />
+</svg>

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.texteditor/full/obj16/open_replace.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.texteditor/full/obj16/open_replace.svg
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   fill="currentColor"
+   version="1.1"
+   id="svg6584"
+   sodipodi:docname="open_replace.svg"
+   inkscape:version="1.2.1 (9c6d41e410, 2022-07-14)"
+   inkscape:export-filename="open_replace@2x.png"
+   inkscape:export-xdpi="192"
+   inkscape:export-ydpi="192"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs6588" />
+  <sodipodi:namedview
+     id="namedview6586"
+     pagecolor="#ffffff"
+     bordercolor="#000000"
+     borderopacity="0.25"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     showgrid="false"
+     inkscape:zoom="64.1875"
+     inkscape:cx="4.7984421"
+     inkscape:cy="7.9922103"
+     inkscape:window-width="3440"
+     inkscape:window-height="1369"
+     inkscape:window-x="-8"
+     inkscape:window-y="-8"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg6584" />
+  <path
+     fill-rule="evenodd"
+     clip-rule="evenodd"
+     d="M10.072 8.024L5.715 3.667l.618-.62L11 7.716v.618L6.333 13l-.618-.619 4.357-4.357z"
+     id="path6582"
+     style="fill:#797979;fill-opacity:1" />
+</svg>


### PR DESCRIPTION
Reintroduce icons for opening/closing the replace area. Icons used in
https://github.com/eclipse-platform/eclipse.platform.ui/pull/1976