### PR TITLE
Delete white filter and empty groups in SVGs

### DIFF
--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.junit/etool16/new_testcase.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.junit/etool16/new_testcase.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="new_testcase.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -112,18 +112,6 @@
          d="m 2.005808,1041.3724 0,0.5 0,11.0313 0,0.5 0.5,0 12.9375,0 0.5,0 0,-0.5 0,-11.0313 0,-0.5 -0.5,0 -12.9375,0 -0.5,0 z"
          style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:Sans;-inkscape-font-specification:Sans;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:nonzero;stroke:none;stroke-width:1;marker:none;enable-background:accumulate" />
     </mask>
-    <filter
-       height="1.4800004"
-       y="-0.24000017"
-       width="1.4799995"
-       x="-0.23999982"
-       id="filter8410"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur8412"
-         stdDeviation="1.4653611"
-         inkscape:collect="always" />
-    </filter>
   </defs>
   <sodipodi:namedview
      inkscape:document-rotation="0"
@@ -133,25 +121,34 @@
      inkscape:guide-bbox="true"
      showguides="true"
      inkscape:window-maximized="1"
-     inkscape:window-y="23"
-     inkscape:window-x="0"
-     inkscape:window-height="1005"
-     inkscape:window-width="1680"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
      inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="7.7875334"
-     inkscape:cx="8.718886"
+     inkscape:cy="7.7796891"
+     inkscape:cx="8.7276777"
      inkscape:zoom="48.52379"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#c9c9c9"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid3999"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -255,23 +252,6 @@
        d="m 3.5,1040.3774 0,9.4848 5.5000002,0"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#49a068;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
        sodipodi:nodetypes="ccc" />
-    <g
-       mask="url(#mask8465)"
-       id="g8461"
-       style="display:inline"
-       transform="matrix(0.6258371,0,0,0.98852889,3.1169292,8.9685178)">
-      <g
-         style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:1.27137804"
-         transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-         id="g7590-1-0">
-        <path
-           style="display:inline;opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:7.44396067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter8410)"
-           d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-           id="rect6501-1-6-8"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="czczczczc" />
-      </g>
-    </g>
     <rect
        transform="matrix(-0.70710678,-0.70710678,0.70710678,-0.70710678,0,0)"
        y="-728.67279"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newannotation_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newannotation_wiz.svg
@@ -1,22 +1,22 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    inkscape:export-ydpi="90"
    inkscape:export-xdpi="90"
    inkscape:export-filename="/home/tmccrary/temp/git/eclipse-svg/src/main/resources/eclipse.jdt.ui/org.eclipse.jdt.ui/icons/full/etool16/newannotation_wiz2.png"
    sodipodi:docname="newannotation_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <mask
@@ -33,111 +33,6 @@
          style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
          sodipodi:type="arc" />
     </mask>
-    <filter
-       inkscape:collect="always"
-       id="filter8410-9-1"
-       x="-0.23999982"
-       width="1.4799995"
-       y="-0.24000017"
-       height="1.4800004"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412-2-6" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9-2"
-       id="linearGradient6323-7-1-1-6"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6-9-4-9-2">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8-0-4-9-2" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3-6-1-7-7" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9-2"
-       id="linearGradient5084-3-3-2-6-0"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9-2"
-       id="linearGradient5086-8-0-8-5-2"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9-2"
-       id="linearGradient5082-1-0-8-1-3"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9-2"
-       id="linearGradient5078-8-2-1-4-3"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9-2"
-       id="linearGradient5076-5-2-9-8-1"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3500-5-6"
-       xlink:href="#linearGradient5068-6-9-4-9-2"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9-2"
-       id="linearGradient5088-1-4-8-6-8"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
     <radialGradient
        r="3.4803574"
        fy="-738.83777"
@@ -187,30 +82,38 @@
      inkscape:guide-bbox="true"
      showguides="true"
      inkscape:snap-global="false"
-     inkscape:window-maximized="0"
-     inkscape:window-y="23"
-     inkscape:window-x="630"
-     inkscape:window-height="1005"
-     inkscape:window-width="1050"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
      inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="7.8767216"
-     inkscape:cx="8.7326512"
+     inkscape:cy="7.882069"
+     inkscape:cx="8.7292779"
      inkscape:zoom="33.049698"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        snapvisiblegridlinesonly="true"
        enabled="true"
        visible="true"
        empspacing="5"
        id="grid2985"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -259,74 +162,9 @@
       </g>
     </g>
     <g
-       transform="translate(-0.8697971,-2.0291496)"
-       style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
-       mask="url(#mask10620)"
-       id="g8461-0">
-      <g
-         style="fill:#ffffff;stroke:#ffffff;display:inline"
-         transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-         id="g7590-1-0-4">
-        <path
-           style="opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503387;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410-9-1)"
-           d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 3517894290.96875,229334007 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-           id="rect6501-1-6-8-6"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="czczczczc" />
-      </g>
-    </g>
-    <g
        transform="translate(15.023334,-10.242077)"
        id="g6432"
        style="display:inline">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1"
-         d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         style="fill:url(#linearGradient6323-7-1-1-6);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1-8"
-         d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         style="fill:url(#linearGradient5084-3-3-2-6-0);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-7"
-         d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-         style="fill:url(#linearGradient5086-8-0-8-5-2);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-6"
-         d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient5082-1-0-8-1-3);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-1"
-         d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient5078-8-2-1-4-3);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-89"
-         d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         style="fill:url(#linearGradient5076-5-2-9-8-1);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-2"
-         d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-         style="fill:url(#linearGradient3500-5-6);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-79"
-         d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         style="fill:url(#linearGradient5088-1-4-8-6-8);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
       <g
          transform="translate(-5.536708,-5.6240351)"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newclass_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newclass_wiz.svg
@@ -1,34 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newclass_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
-    <filter
-       inkscape:collect="always"
-       id="filter8410-9-1"
-       x="-0.23999982"
-       width="1.4799995"
-       y="-0.24000017"
-       height="1.4800004"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412-2-6" />
-    </filter>
     <mask
        id="mask10620"
        maskUnits="userSpaceOnUse">
@@ -43,18 +30,6 @@
          style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.16621375;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline;font-family:Sans"
          sodipodi:type="arc" />
     </mask>
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6-9-4-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8-0-4-9" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3-6-1-7" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4528-9-5-7-9-7-3">
       <stop
@@ -77,86 +52,6 @@
          offset="1"
          id="stop6285-5-0-9-7-6-9-9-1-9" />
     </linearGradient>
-    <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3329"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       gradientTransform="matrix(1,0,0,0.58744691,-15.015625,440.09687)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3331"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3333"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       gradientTransform="matrix(1,0,0,0.58744691,-15.015625,440.09687)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3335"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3337"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3339"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3341"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3343"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
     <radialGradient
        r="3.4803574"
        fy="-738.83777"
@@ -207,25 +102,34 @@
      inkscape:document-rotation="0"
      inkscape:snap-global="false"
      inkscape:window-maximized="0"
-     inkscape:window-y="89"
+     inkscape:window-y="34"
      inkscape:window-x="216"
      inkscape:window-height="939"
      inkscape:window-width="1419"
      showgrid="true"
-     inkscape:current-layer="g6432"
+     inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="7.8908341"
-     inkscape:cx="9.2338952"
+     inkscape:cy="7.8996305"
+     inkscape:cx="9.2146121"
      inkscape:zoom="51.331515"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid10382"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -246,50 +150,13 @@
      inkscape:groupmode="layer"
      inkscape:label="Layer 1">
     <g
-       id="g11331-3-1-1"
-       style="display:inline"
-       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)">
-      <g
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
-         id="g13408-8" />
-    </g>
-    <g
        id="g6124-3"
        style="display:inline"
        transform="matrix(-1,0,0,1,16.12959,8.0140628)">
       <g
-         id="text6430"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
-         transform="scale(-1,1)" />
-      <g
          id="g6438"
          style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
          transform="scale(-1,1)">
-        <g
-           transform="translate(-16.999387,-10.043212)"
-           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
-           mask="url(#mask10620)"
-           id="g8461-0">
-          <g
-             style="fill:#ffffff;stroke:#ffffff;display:inline"
-             transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-             id="g7590-1-0-4">
-            <path
-               style="opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503387;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410-9-1)"
-               d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-               id="rect6501-1-6-8-6"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="czczczczc" />
-          </g>
-        </g>
-        <g
-           transform="translate(0.0625,0.625)"
-           id="g10525">
-          <g
-             id="g7590-1-9"
-             transform="matrix(0.51237963,0,0,0.51237963,4.5386346,504.16212)"
-             style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans" />
-        </g>
         <g
            id="g4193"
            style="display:inline"
@@ -298,10 +165,6 @@
              id="g6124-3-3"
              style="display:inline"
              transform="matrix(-1,0,0,1,16.12959,8.0140628)">
-            <g
-               id="text6430-8"
-               style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-               transform="scale(-1,1)" />
             <g
                id="g6438-8"
                style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
@@ -313,10 +176,6 @@
                  cx="388.125"
                  cy="468.23718"
                  r="8.9586821" />
-              <g
-                 id="text3782"
-                 style="font-size:15.56941891px;font-family:Sans;fill:#ffffff"
-                 transform="scale(0.94400511,1.0593163)" />
             </g>
           </g>
           <path
@@ -331,54 +190,6 @@
          transform="matrix(-1,0,0,1,1.137506,-18.25614)"
          id="g6432"
          style="display:inline">
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path5581-1-1"
-           d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-           style="fill:url(#linearGradient3329);fill-opacity:1;stroke:none;display:inline" />
-        <path
-           sodipodi:nodetypes="cccccc"
-           inkscape:connector-curvature="0"
-           id="path5581-1-1-8"
-           d="m -5.007813,1054.1825 4,0 0,-0.5874 -0.476562,-0.2846 -2.03125,0 z"
-           style="display:inline;fill:url(#linearGradient3331);fill-opacity:1;stroke:none" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-7"
-           d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-           style="fill:url(#linearGradient3333);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-6"
-           d="m -5.007813,1053.0076 0,1.1749 1.492188,-0.872 0,-1.1749 z"
-           style="display:inline;fill:url(#linearGradient3335);fill-opacity:1;stroke:none"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-1"
-           d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-           style="fill:url(#linearGradient3337);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-89"
-           d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-           style="fill:url(#linearGradient3339);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-2"
-           d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-           style="fill:url(#linearGradient3341);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-79"
-           d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-           style="fill:url(#linearGradient3343);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
         <g
            transform="translate(-5.536708,-5.6240351)"
            id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newenum_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newenum_wiz.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newenum_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -40,19 +40,6 @@
          offset="1"
          style="stop-color:#c7af93;stop-opacity:1" />
     </linearGradient>
-    <filter
-       inkscape:collect="always"
-       id="filter8410-9-1"
-       x="-0.23999982"
-       width="1.4799995"
-       y="-0.24000017"
-       height="1.4800004"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412-2-6" />
-    </filter>
     <mask
        id="mask10620"
        maskUnits="userSpaceOnUse">
@@ -69,104 +56,16 @@
     </mask>
     <filter
        id="filter8104"
-       inkscape:collect="always">
+       inkscape:collect="always"
+       x="-0.068571429"
+       y="-0.053333333"
+       width="1.1371429"
+       height="1.1066667">
       <feGaussianBlur
          id="feGaussianBlur8106"
          stdDeviation="0.15625"
          inkscape:collect="always" />
     </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient6323-7-1-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6-9-4-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8-0-4-9" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3-6-1-7" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5084-3-3-2-6"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5086-8-0-8-5"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5082-1-0-8-1"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5078-8-2-1-4"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5076-5-2-9-8"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3500-5"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5088-1-4-8-6"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
     <radialGradient
        r="3.4803574"
        fy="-738.83777"
@@ -214,26 +113,35 @@
   <sodipodi:namedview
      inkscape:document-rotation="0"
      inkscape:snap-global="false"
-     inkscape:window-maximized="0"
-     inkscape:window-y="181"
-     inkscape:window-x="755"
-     inkscape:window-height="847"
-     inkscape:window-width="925"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
-     inkscape:current-layer="g6438"
+     inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="7.8767227"
-     inkscape:cx="8.7326498"
+     inkscape:cy="7.8759797"
+     inkscape:cx="8.7176875"
      inkscape:zoom="24.949277"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid10382"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -254,21 +162,9 @@
      inkscape:groupmode="layer"
      inkscape:label="Layer 1">
     <g
-       id="g11331-3-1-1"
-       style="display:inline"
-       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)">
-      <g
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
-         id="g13408-8" />
-    </g>
-    <g
        id="g6124-3"
        style="display:inline"
        transform="matrix(-1,0,0,1,16.12959,8.0140628)">
-      <g
-         id="text6430"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
-         transform="scale(-1,1)" />
       <g
          id="g6438"
          style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
@@ -283,23 +179,6 @@
            id="path10796-2-6-2"
            style="fill:url(#linearGradient3929-5);fill-opacity:1;stroke:#905e27;stroke-width:2.16621374999999983;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
            sodipodi:type="arc" />
-        <g
-           transform="translate(-16.999387,-10.043212)"
-           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
-           mask="url(#mask10620)"
-           id="g8461-0">
-          <g
-             style="fill:#ffffff;stroke:#ffffff;display:inline"
-             transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-             id="g7590-1-0-4">
-            <path
-               style="opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503387;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410-9-1)"
-               d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-               id="rect6501-1-6-8-6"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="czczczczc" />
-          </g>
-        </g>
         <g
            transform="translate(-21,1.9999927)"
            id="g8046">
@@ -332,9 +211,6 @@
              x="9.87041"
              y="1034.3481" />
         </g>
-        <g
-           transform="translate(0.25,0.6875)"
-           id="g10525" />
         <g
            transform="translate(-20.875,2.1249927)"
            id="g8046-4"
@@ -372,54 +248,6 @@
            transform="translate(-1.106256,-18.25614)"
            id="g6432"
            style="display:inline">
-          <path
-             sodipodi:nodetypes="ccccc"
-             inkscape:connector-curvature="0"
-             id="path5581-1-1"
-             d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-             style="fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none;display:inline" />
-          <path
-             sodipodi:nodetypes="cccccc"
-             inkscape:connector-curvature="0"
-             id="path5581-1-1-8"
-             d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-             style="fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none;display:inline" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-7"
-             d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-             style="fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-6"
-             d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-             style="fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-1"
-             d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-             style="fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-89"
-             d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-             style="fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-2"
-             d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-             style="fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-79"
-             d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-             style="fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
           <g
              transform="translate(-5.536708,-5.6240351)"
              id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newint_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newint_wiz.svg
@@ -1,113 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newint_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient6323-7-1-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6-9-4-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8-0-4-9" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3-6-1-7" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5084-3-3-2-6"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5086-8-0-8-5"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5082-1-0-8-1"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5078-8-2-1-4"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5076-5-2-9-8"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3500-5"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5088-1-4-8-6"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
     <radialGradient
        r="3.4803574"
        fy="-738.83777"
@@ -179,26 +87,35 @@
   <sodipodi:namedview
      inkscape:document-rotation="0"
      inkscape:snap-global="false"
-     inkscape:window-maximized="0"
-     inkscape:window-y="181"
-     inkscape:window-x="755"
-     inkscape:window-height="847"
-     inkscape:window-width="925"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
      inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="7.9430153"
-     inkscape:cx="8.7547533"
+     inkscape:cy="7.9333499"
+     inkscape:cx="8.7326799"
      inkscape:zoom="25.020956"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid10382"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -218,14 +135,6 @@
      id="layer1"
      inkscape:groupmode="layer"
      inkscape:label="Layer 1">
-    <g
-       id="g11331-3-1-1"
-       style="display:inline"
-       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)">
-      <g
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1"
-         id="g13408-8" />
-    </g>
     <g
        transform="translate(-16.440233,9.5017478)"
        id="g3093">
@@ -250,54 +159,6 @@
        transform="translate(15.023334,-10.242077)"
        id="g6432"
        style="display:inline">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1"
-         d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         style="fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1-8"
-         d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         style="fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-7"
-         d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-         style="fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-6"
-         d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-1"
-         d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-89"
-         d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         style="fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-2"
-         d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-         style="fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-79"
-         d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         style="fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
       <g
          transform="translate(-5.536708,-5.6240351)"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newjprj_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newjprj_wiz.svg
@@ -1,33 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newjprj_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
-    <filter
-       inkscape:collect="always"
-       id="filter8410"
-       x="-0.23999982"
-       width="1.4799996"
-       y="-0.24000018"
-       height="1.4800004">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412" />
-    </filter>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4748"
@@ -81,10 +69,10 @@
     <filter
        inkscape:collect="always"
        id="filter4929"
-       x="-0.13757156"
-       width="1.2751431"
-       y="-0.37744917"
-       height="1.7548983">
+       x="-0.31518737"
+       width="1.6303747"
+       y="-0.42999801"
+       height="1.859996">
       <feGaussianBlur
          inkscape:collect="always"
          stdDeviation="3.5620748"
@@ -253,10 +241,10 @@
     <filter
        inkscape:collect="always"
        id="filter4929-9"
-       x="-0.13757156"
-       width="1.2751431"
-       y="-0.37744918"
-       height="1.7548983"
+       x="-0.31518737"
+       width="1.6303747"
+       y="-0.42999801"
+       height="1.859996"
        color-interpolation-filters="sRGB">
       <feGaussianBlur
          inkscape:collect="always"
@@ -591,10 +579,10 @@
     <filter
        inkscape:collect="always"
        id="filter4929-5"
-       x="-0.13757156"
-       width="1.2751431"
-       y="-0.37744918"
-       height="1.7548983"
+       x="-0.31518737"
+       width="1.6303747"
+       y="-0.42999801"
+       height="1.859996"
        color-interpolation-filters="sRGB">
       <feGaussianBlur
          inkscape:collect="always"
@@ -695,110 +683,6 @@
         </g>
       </g>
     </mask>
-    <filter
-       height="1.2700664"
-       y="-0.13503321"
-       width="1.5397345"
-       x="-0.26986725"
-       id="filter17488"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur17490"
-         stdDeviation="0.42649235"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient6323-7-1-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6-9-4-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8-0-4-9" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3-6-1-7" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5084-3-3-2-6"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5086-8-0-8-5"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5082-1-0-8-1"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5078-8-2-1-4"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5076-5-2-9-8"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3500-5"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5088-1-4-8-6"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
     <linearGradient
        y2="7.549418"
        x2="0.9375"
@@ -824,26 +708,35 @@
   <sodipodi:namedview
      inkscape:document-rotation="0"
      inkscape:snap-global="false"
-     inkscape:window-maximized="0"
-     inkscape:window-y="52"
-     inkscape:window-x="208"
-     inkscape:window-height="976"
-     inkscape:window-width="1096"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
-     inkscape:current-layer="g4522"
+     inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="8.3842194"
-     inkscape:cx="8.3550368"
+     inkscape:cy="8.3795371"
+     inkscape:cx="8.349449"
      inkscape:zoom="33.235726"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid3947"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -950,16 +843,6 @@
         </g>
       </g>
     </g>
-    <g
-       mask="url(#mask17458)"
-       id="g17455">
-      <path
-         sodipodi:nodetypes="ssscccssscccscss"
-         inkscape:connector-curvature="0"
-         id="path10927-5-7-9-7"
-         d="m 5.70269,1044.9373 c -0.185041,-0.018 -0.402396,-0.059 -0.576929,-0.1108 -0.270837,-0.079 -0.243851,0.015 -0.243851,-0.8593 0,-0.4579 0.0077,-0.7598 0.01951,-0.7646 0.01072,0 0.0317,0 0.04665,0.013 0.04847,0.037 0.294579,0.1623 0.376062,0.1926 0.186482,0.069 0.46629,0.1032 0.663393,0.083 0.436936,-0.047 0.733026,-0.2945 0.881951,-0.7389 0.120095,-0.3583 0.114052,-0.2194 0.12641,-2.9086 l 0.01137,-2.4738 0.829393,0 0.829395,0 0.0062,2.3061 c 0.0064,2.384 -5.49e-4,2.6629 -0.0777,3.0973 -0.156267,0.8809 -0.598495,1.5436 -1.254122,1.8796 -0.440731,0.2258 -1.0806,0.337 -1.637678,0.2843 z"
-         style="fill:#ffffff;fill-opacity:1;display:inline;filter:url(#filter17488);opacity:0.75000000000000000;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none" />
-    </g>
     <path
        style="fill:#366c9a;fill-opacity:1;display:inline"
        d="m 5.70269,1044.9373 c -0.185041,-0.018 -0.402396,-0.059 -0.576929,-0.1108 -0.270837,-0.079 -0.243851,0.015 -0.243851,-0.8593 0,-0.4579 0.0077,-0.7598 0.01951,-0.7646 0.01072,0 0.0317,0 0.04665,0.013 0.04847,0.037 0.294579,0.1623 0.376062,0.1926 0.186482,0.069 0.46629,0.1032 0.663393,0.083 0.436936,-0.047 0.733026,-0.2945 0.881951,-0.7389 0.120095,-0.3583 0.114052,-0.2194 0.12641,-2.9086 l 0.01137,-2.4738 0.829393,0 0.829395,0 0.0062,2.3061 c 0.0064,2.384 -5.49e-4,2.6629 -0.0777,3.0973 -0.156267,0.8809 -0.598495,1.5436 -1.254122,1.8796 -0.440731,0.2258 -1.0806,0.337 -1.637678,0.2843 z"
@@ -967,83 +850,9 @@
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="ssscccssscccscss" />
     <g
-       mask="url(#mask17098)"
-       id="g7590-7"
-       style="display:inline"
-       transform="translate(0.696415,25.515546)" />
-    <g
-       mask="url(#mask17064)"
-       id="g7827-7"
-       style="display:inline"
-       transform="matrix(0.40514455,0,0,0.40514455,61.307445,630.5533)" />
-    <g
-       mask="url(#mask17030)"
-       id="g8461"
-       transform="translate(-0.888856,-1.9408198)">
-      <g
-         style="fill:#ffffff;stroke:#ffffff;display:inline"
-         transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-         id="g7590-1-0">
-        <path
-           style="opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503387;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410)"
-           d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-           id="rect6501-1-6-8"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="czczczczc" />
-      </g>
-    </g>
-    <g
        transform="translate(14.958406,-10.242077)"
        id="g6432"
        style="display:inline">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1"
-         d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         style="display:inline;fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1-8"
-         d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         style="display:inline;fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-7"
-         d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-         style="display:inline;fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-6"
-         d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-         style="display:inline;fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-1"
-         d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-         style="display:inline;fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-89"
-         d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         style="display:inline;fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-2"
-         d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-         style="display:inline;fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-79"
-         d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         style="display:inline;fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none"
-         inkscape:connector-curvature="0" />
       <g
          transform="translate(-5.536708,-5.6240351)"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newpack_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newpack_wiz.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newpack_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -59,19 +59,6 @@
          offset="1"
          style="stop-color:#5f392d;stop-opacity:1" />
     </linearGradient>
-    <filter
-       inkscape:collect="always"
-       id="filter8410-6-5"
-       x="-0.23999982"
-       width="1.4799995"
-       y="-0.24000017"
-       height="1.4800004"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412-5-3" />
-    </filter>
     <linearGradient
        id="linearGradient11146-4-4-4-6-2">
       <stop
@@ -282,98 +269,6 @@
            id="g10867" />
       </g>
     </mask>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient6323-7-1-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6-9-4-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8-0-4-9" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3-6-1-7" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5084-3-3-2-6"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5086-8-0-8-5"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5082-1-0-8-1"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5078-8-2-1-4"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5076-5-2-9-8"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3500-5"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5088-1-4-8-6"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
     <radialGradient
        r="3.4803574"
        fy="-738.83777"
@@ -422,25 +317,34 @@
      inkscape:document-rotation="0"
      inkscape:snap-global="true"
      inkscape:window-maximized="1"
-     inkscape:window-y="23"
-     inkscape:window-x="0"
-     inkscape:window-height="1005"
-     inkscape:window-width="1680"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
-     inkscape:current-layer="g13862"
+     inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="7.8852222"
-     inkscape:cx="8.7239637"
-     inkscape:zoom="56.010183"
+     inkscape:cy="7.8021527"
+     inkscape:cx="6.4452566"
+     inkscape:zoom="28.005092"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid3947"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -517,94 +421,11 @@
              inkscape:connector-curvature="0"
              sodipodi:nodetypes="cc" />
         </g>
-        <g
-           transform="matrix(0.27903303,0,0,0.27903303,-64.52871,915.34629)"
-           style="display:inline"
-           id="g11331-3" />
       </g>
-      <g
-         style="opacity:0.75"
-         mask="url(#mask10847)"
-         id="g14097">
-        <g
-           id="g8461"
-           mask="none"
-           style="display:inline"
-           transform="matrix(3.5838051,0,0,3.5838051,461.05274,-3375.5799)">
-          <g
-             id="g7590-1-0"
-             transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-             style="fill:#ffffff;stroke:#ffffff;display:inline">
-            <path
-               sodipodi:nodetypes="czczczczc"
-               inkscape:connector-curvature="0"
-               id="rect6501-1-6-8"
-               d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-               style="opacity:1;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503386999999975;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410-6-5)" />
-          </g>
-        </g>
-      </g>
-      <g
-         style="fill:#ffffff;stroke:#ffffff;display:inline"
-         transform="matrix(1.1835826,0,0,1.1835826,-72.087418,-81.712528)"
-         id="g14104" />
-      <g
-         mask="none"
-         id="g6258"
-         style="display:inline"
-         transform="matrix(1.1835826,0,0,1.1835826,-72.087418,-81.712526)" />
       <g
          transform="matrix(3.5838051,0,0,3.5838051,517.985,-3405.2903)"
          id="g6432"
          style="display:inline">
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path5581-1-1"
-           d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-           style="fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none;display:inline" />
-        <path
-           sodipodi:nodetypes="cccccc"
-           inkscape:connector-curvature="0"
-           id="path5581-1-1-8"
-           d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-           style="fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none;display:inline" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-7"
-           d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-           style="fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-6"
-           d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-           style="fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-1"
-           d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-           style="fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-89"
-           d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-           style="fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-2"
-           d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-           style="fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-79"
-           d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-           style="fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
         <g
            transform="translate(-5.536708,-5.6240351)"
            id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newpackfolder_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.jdt.ui/etool16/newpackfolder_wiz.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newpackfolder_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -221,19 +221,6 @@
          offset="1"
          style="stop-color:#663e32;stop-opacity:1" />
     </linearGradient>
-    <filter
-       inkscape:collect="always"
-       id="filter8410-6-5"
-       x="-0.23999982"
-       width="1.4799995"
-       y="-0.24000017"
-       height="1.4800004"
-       color-interpolation-filters="sRGB">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412-5-3" />
-    </filter>
     <mask
        id="mask14102"
        maskUnits="userSpaceOnUse">
@@ -326,98 +313,6 @@
        id="linearGradient14890"
        xlink:href="#linearGradient7275-7"
        inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient6323-7-1-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6-9-4-9">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8-0-4-9" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3-6-1-7" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5084-3-3-2-6"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5086-8-0-8-5"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5082-1-0-8-1"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5078-8-2-1-4"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5076-5-2-9-8"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3500-5"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient5088-1-4-8-6"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
     <radialGradient
        r="3.4803574"
        fy="-738.83777"
@@ -465,26 +360,35 @@
   <sodipodi:namedview
      inkscape:document-rotation="0"
      inkscape:snap-global="false"
-     inkscape:window-maximized="0"
-     inkscape:window-y="290"
-     inkscape:window-x="659"
-     inkscape:window-height="738"
-     inkscape:window-width="1021"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
      inkscape:current-layer="g13862"
      inkscape:document-units="px"
-     inkscape:cy="7.8690682"
-     inkscape:cx="8.2236831"
+     inkscape:cy="7.8484432"
+     inkscape:cx="8.1904233"
      inkscape:zoom="29.241468"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid3947"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -533,41 +437,10 @@
            style="fill:none;stroke:url(#linearGradient3945);stroke-width:3.02792978;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
       </g>
       <g
-         style="opacity:0.5"
-         mask="url(#mask14102)"
-         id="g14097">
-        <g
-           id="g8461"
-           mask="none"
-           style="display:inline"
-           transform="matrix(3.5838051,0,0,3.5838051,461.05274,-3375.5799)">
-          <g
-             id="g7590-1-0"
-             transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-             style="fill:#ffffff;stroke:#ffffff;display:inline">
-            <path
-               sodipodi:nodetypes="czczczczc"
-               inkscape:connector-curvature="0"
-               id="rect6501-1-6-8"
-               d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-               style="opacity:0.84999999999999998;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503386999999975;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410-6-5)" />
-          </g>
-        </g>
-      </g>
-      <g
-         mask="none"
-         id="g6258"
-         style="display:inline"
-         transform="matrix(1.1835826,0,0,1.1835826,-72.087418,-81.712526)" />
-      <g
          inkscape:label="Layer 1"
          id="layer1-9"
          style="display:inline"
          transform="matrix(3.5838051,0,0,3.5838051,535.64691,-3346.8434)">
-        <g
-           transform="matrix(0.27903303,0,0,0.27903303,-64.52871,915.34629)"
-           style="display:inline"
-           id="g11331-3" />
         <g
            style="display:inline"
            transform="matrix(0.27903303,0,0,0.27903303,-120.09325,915.23237)"
@@ -616,54 +489,6 @@
          transform="matrix(3.5838051,0,0,3.5838051,517.985,-3405.2903)"
          id="g6432"
          style="display:inline">
-        <path
-           sodipodi:nodetypes="ccccc"
-           inkscape:connector-curvature="0"
-           id="path5581-1-1"
-           d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-           style="fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none;display:inline" />
-        <path
-           sodipodi:nodetypes="cccccc"
-           inkscape:connector-curvature="0"
-           id="path5581-1-1-8"
-           d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-           style="fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none;display:inline" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-7"
-           d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-           style="fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-6"
-           d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-           style="fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-1"
-           d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-           style="fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-89"
-           d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-           style="fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-2"
-           d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-           style="fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
-        <path
-           sodipodi:nodetypes="ccccc"
-           id="path5581-1-1-79"
-           d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-           style="fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none;display:inline"
-           inkscape:connector-curvature="0" />
         <g
            transform="translate(-5.536708,-5.6240351)"
            id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.ui.console/elcl16/new_con.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.jdt.doc.user/images/org.eclipse.ui.console/elcl16/new_con.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="new_con.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -108,28 +108,16 @@
          id="stop4086-2" />
     </linearGradient>
     <filter
-       height="1.220829"
-       y="-0.11041452"
-       width="1.169829"
-       x="-0.084914483"
+       height="1.382678"
+       y="-0.16038014"
+       width="1.4377165"
+       x="-0.18344673"
        id="filter7823-3-4-6"
        inkscape:collect="always"
        color-interpolation-filters="sRGB">
       <feGaussianBlur
          id="feGaussianBlur7825-1-3-8"
          stdDeviation="1.6188839"
-         inkscape:collect="always" />
-    </filter>
-    <filter
-       height="1.4800004"
-       y="-0.24000018"
-       width="1.4799996"
-       x="-0.23999982"
-       id="filter8410"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur8412"
-         stdDeviation="1.4653611"
          inkscape:collect="always" />
     </filter>
     <mask
@@ -190,26 +178,35 @@
      inkscape:snap-global="false"
      inkscape:guide-bbox="true"
      showguides="true"
-     inkscape:window-maximized="0"
-     inkscape:window-y="404"
-     inkscape:window-x="694"
-     inkscape:window-height="624"
-     inkscape:window-width="986"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
      inkscape:current-layer="layer1-8"
      inkscape:document-units="px"
-     inkscape:cy="8.1817237"
-     inkscape:cx="8.7602831"
+     inkscape:cy="8.1644023"
+     inkscape:cx="8.738602"
      inkscape:zoom="27.864869"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid6272"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -261,29 +258,6 @@
            id="rect3997-9-9"
            inkscape:connector-curvature="0"
            sodipodi:nodetypes="ccccc" />
-        <g
-           id="g7590-7"
-           style="display:inline"
-           transform="translate(-12.593765,20.531347)" />
-        <g
-           id="g7827-7"
-           style="display:inline"
-           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)" />
-        <g
-           mask="url(#mask8465)"
-           id="g8461">
-          <g
-             style="display:inline;fill:#ffffff;stroke:#ffffff"
-             transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-             id="g7590-1-0">
-            <path
-               style="opacity:0.84999999999999998;fill:#ffffff;stroke:#ffffff;stroke-width:5.8550337;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410)"
-               d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-               id="rect6501-1-6-8"
-               inkscape:connector-curvature="0"
-               sodipodi:nodetypes="czczczczc" />
-          </g>
-        </g>
         <path
            style="fill:none;stroke:#ffe99f;stroke-width:3;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter7823-3-4-6)"
            d="m -106.1326,1054.8481 c 15.377466,0 21.179561,-6.8234 21.179561,-24.2257"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/new_persp.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/new_persp.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="new_persp.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -229,88 +229,6 @@
        id="linearGradient8703"
        xlink:href="#linearGradient8337-1"
        inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4"
-       id="linearGradient6323-7-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6-9-4">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8-0-4" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3-6-1" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4"
-       id="linearGradient5084-3-3-2"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4"
-       id="linearGradient5086-8-0-8"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4"
-       id="linearGradient5082-1-0-8"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4"
-       id="linearGradient5078-8-2-1"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4"
-       id="linearGradient5076-5-2-9"
-       x1="10.117188"
-       y1="1040.0653"
-       x2="10"
-       y2="1039.0497"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4"
-       id="linearGradient5088-1-4-8"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
     <radialGradient
        r="3.4803574"
        fy="-738.83777"
@@ -358,26 +276,35 @@
   <sodipodi:namedview
      inkscape:document-rotation="0"
      inkscape:snap-global="false"
-     inkscape:window-maximized="0"
-     inkscape:window-y="280"
-     inkscape:window-x="563"
-     inkscape:window-height="468"
-     inkscape:window-width="776"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
-     inkscape:current-layer="g6432"
+     inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="8"
-     inkscape:cx="8"
+     inkscape:cy="7.9661017"
+     inkscape:cx="7.9661017"
      inkscape:zoom="14.75"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid4759"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -478,10 +405,6 @@
          sodipodi:nodetypes="ssccsss" />
     </g>
     <g
-       id="g11029"
-       style="stroke:#694337;stroke-opacity:1;display:inline"
-       transform="translate(-20.000002,2.6171874e-6)" />
-    <g
        transform="matrix(0.90974503,0,0,0.90974503,0.94380764,95.200178)"
        id="g4761">
       <g
@@ -565,48 +488,6 @@
            transform="matrix(1.0992091,0,0,1.0992091,14.12881,-115.43836)"
            id="g6432"
            style="display:inline">
-          <path
-             sodipodi:nodetypes="ccccc"
-             inkscape:connector-curvature="0"
-             id="path5581-1-1"
-             d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-             style="fill:url(#linearGradient6323-7-1);fill-opacity:1;stroke:none;display:inline" />
-          <path
-             sodipodi:nodetypes="cccccc"
-             inkscape:connector-curvature="0"
-             id="path5581-1-1-8"
-             d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-             style="fill:url(#linearGradient5084-3-3-2);fill-opacity:1;stroke:none;display:inline" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-7"
-             d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-             style="fill:url(#linearGradient5086-8-0-8);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-6"
-             d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-             style="fill:url(#linearGradient5082-1-0-8);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-1"
-             d="m -7.007813,1049.62 0,4 1.4609376,-1.4844 0.15625,-1.8281 z"
-             style="display:inline;fill:url(#linearGradient5078-8-2-1);fill-opacity:1;stroke:none"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-89"
-             d="m -5.007813,1049.6512 -1.9023438,0.01 1.5241078,0.6485 1.511049,-0.1407 z"
-             style="display:inline;fill:url(#linearGradient5076-5-2-9);fill-opacity:1;stroke:none"
-             inkscape:connector-curvature="0" />
-          <path
-             sodipodi:nodetypes="ccccc"
-             id="path5581-1-1-79"
-             d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-             style="fill:url(#linearGradient5088-1-4-8);fill-opacity:1;stroke:none;display:inline"
-             inkscape:connector-curvature="0" />
           <g
              transform="translate(-5.536708,-5.6240351)"
              id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/new_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/new_wiz.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
-   sodipodi:docname="new_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -111,26 +111,14 @@
        color-interpolation-filters="sRGB"
        inkscape:collect="always"
        id="filter7823-3-4-6"
-       x="-0.084914483"
-       width="1.169829"
-       y="-0.11041452"
-       height="1.220829">
+       x="-0.18344673"
+       width="1.4377165"
+       y="-0.16038014"
+       height="1.382678">
       <feGaussianBlur
          inkscape:collect="always"
          stdDeviation="1.6188839"
          id="feGaussianBlur7825-1-3-8" />
-    </filter>
-    <filter
-       inkscape:collect="always"
-       id="filter8410"
-       x="-0.23999982"
-       width="1.4799996"
-       y="-0.24000018"
-       height="1.4800004">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412" />
     </filter>
     <mask
        maskUnits="userSpaceOnUse"
@@ -141,98 +129,6 @@
          id="path8467"
          inkscape:connector-curvature="0" />
     </mask>
-    <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6323-7"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient5068-6-9"
-       inkscape:collect="always">
-      <stop
-         id="stop5070-8-0"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5072-3-6"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       id="linearGradient5084-3-3"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       id="linearGradient5086-8-0"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       id="linearGradient5082-1-0"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       id="linearGradient5078-8-2"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       id="linearGradient5076-5-2"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       id="linearGradient5074-2-1"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       id="linearGradient5088-1-4"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9-5-7-9"
@@ -285,23 +181,32 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="22.627417"
-     inkscape:cx="3.0083715"
-     inkscape:cy="2.3446788"
+     inkscape:cx="3.0273009"
+     inkscape:cy="2.3643883"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="1208"
-     inkscape:window-height="913"
-     inkscape:window-x="472"
-     inkscape:window-y="93"
-     inkscape:window-maximized="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
      showguides="true"
      inkscape:guide-bbox="true"
      inkscape:snap-global="false"
-     inkscape:document-rotation="0">
+     inkscape:document-rotation="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid6272" />
+       id="grid6272"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -353,29 +258,6 @@
            id="rect3997-9-9"
            d="m 2.500702,1041.8621 12.883511,0 0,2.0053 -12.883511,0 z"
            style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-        <g
-           transform="translate(-12.593765,20.531347)"
-           style="display:inline"
-           id="g7590-7" />
-        <g
-           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
-           style="display:inline"
-           id="g7827-7" />
-        <g
-           id="g8461"
-           mask="url(#mask8465)">
-          <g
-             id="g7590-1-0"
-             transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-             style="display:inline;fill:#ffffff;stroke:#ffffff">
-            <path
-               sodipodi:nodetypes="czczczczc"
-               inkscape:connector-curvature="0"
-               id="rect6501-1-6-8"
-               d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-               style="opacity:0.84999999999999998;fill:#ffffff;stroke:#ffffff;stroke-width:5.8550337;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410)" />
-          </g>
-        </g>
         <path
            transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
            sodipodi:nodetypes="cc"
@@ -419,54 +301,6 @@
            style="display:inline"
            id="g6432"
            transform="translate(15.96379,-8.280374)">
-          <path
-             style="fill:url(#linearGradient6323-7);fill-opacity:1;stroke:none;display:inline"
-             d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-             id="path5581-1-1"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             style="fill:url(#linearGradient5084-3-3);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-             id="path5581-1-1-8"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5086-8-0);fill-opacity:1;stroke:none;display:inline"
-             d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-             id="path5581-1-1-7"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5082-1-0);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-             id="path5581-1-1-6"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5078-8-2);fill-opacity:1;stroke:none;display:inline"
-             d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-             id="path5581-1-1-1"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5076-5-2);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-             id="path5581-1-1-89"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5074-2-1);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-             id="path5581-1-1-2"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5088-1-4);fill-opacity:1;stroke:none;display:inline"
-             d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-             id="path5581-1-1-79"
-             sodipodi:nodetypes="ccccc" />
           <g
              style="display:inline"
              id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/newfile_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/newfile_wiz.svg
@@ -1,33 +1,21 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newfile_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
-    <linearGradient
-       id="linearGradient5068"
-       inkscape:collect="always">
-      <stop
-         id="stop5070"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5072"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
     <linearGradient
        id="linearGradient4815"
        inkscape:collect="always">
@@ -71,86 +59,6 @@
        x1="8"
        id="linearGradient4821"
        xlink:href="#linearGradient4815"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-0.0078125,1036.3778)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3050"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3056"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3058"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3060"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3062"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3064"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3066"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3068"
-       xlink:href="#linearGradient5068"
        inkscape:collect="always" />
     <radialGradient
        r="3.4803574"
@@ -202,25 +110,34 @@
      inkscape:guide-bbox="true"
      showguides="true"
      inkscape:window-maximized="1"
-     inkscape:window-y="23"
-     inkscape:window-x="0"
-     inkscape:window-height="1005"
-     inkscape:window-width="1680"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="false"
      inkscape:current-layer="g3038"
      inkscape:document-units="px"
-     inkscape:cy="8"
-     inkscape:cx="8"
-     inkscape:zoom="49.8125"
+     inkscape:cy="7.8784294"
+     inkscape:cx="4.897402"
+     inkscape:zoom="35.222757"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        id="grid3971"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -255,54 +172,6 @@
     <g
        transform="matrix(1.1954268,0,0,1.1954268,-2.4071696,-204.29183)"
        id="g3038">
-      <path
-         style="fill:url(#linearGradient3050);fill-opacity:1;stroke:none;display:inline"
-         d="m 8,1043.3622 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         id="path5581-1-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:url(#linearGradient3056);fill-opacity:1;stroke:none;display:inline"
-         d="m 10,1045.3622 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         id="path5581-1-1-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient3058);fill-opacity:1;stroke:none;display:inline"
-         d="m 13.523438,1041.8778 0,2 0.476562,0.4844 0,-2 z"
-         id="path5581-1-1-7"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient3060);fill-opacity:1;stroke:none;display:inline"
-         d="m 10,1043.3622 0,2 1.492188,-1.4844 0,-2 z"
-         id="path5581-1-1-6"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient3062);fill-opacity:1;stroke:none;display:inline"
-         d="m 8,1038.3622 0,5 1.4609376,-1.4844 1.7544454,-2 z"
-         id="path5581-1-1-1"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient3064);fill-opacity:1;stroke:none;display:inline"
-         d="m 10,1038.3622 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         id="path5581-1-1-89"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient3066);fill-opacity:1;stroke:none;display:inline"
-         d="m 10,1038.3622 0,0 1.503907,1.5273 0,-1.5156 z"
-         id="path5581-1-1-2"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient3068);fill-opacity:1;stroke:none;display:inline"
-         d="m 13.996095,1041.8778 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         id="path5581-1-1-79"
-         sodipodi:nodetypes="ccccc" />
       <g
          transform="matrix(0.83652132,0,0,0.83652132,9.9187208,156.77841)"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/newfolder_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/newfolder_wiz.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newfolder_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg25490"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs25492">
     <linearGradient
@@ -115,98 +115,6 @@
        id="linearGradient5318"
        xlink:href="#linearGradient3967-5"
        inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6"
-       id="linearGradient5088-1"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       id="linearGradient5068-6">
-      <stop
-         style="stop-color:#ffffff;stop-opacity:1;"
-         offset="0"
-         id="stop5070-8" />
-      <stop
-         style="stop-color:#ffffff;stop-opacity:0;"
-         offset="1"
-         id="stop5072-3" />
-    </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6"
-       id="linearGradient5074-2"
-       x1="12"
-       y1="1038.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6"
-       id="linearGradient5076-5"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6"
-       id="linearGradient5078-8"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6"
-       id="linearGradient5082-1"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6"
-       id="linearGradient5086-8"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6"
-       id="linearGradient5084-3"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6"
-       id="linearGradient6323"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
     <radialGradient
        r="3.4803574"
        fy="-738.83777"
@@ -254,7 +162,7 @@
   <sodipodi:namedview
      inkscape:document-rotation="0"
      inkscape:window-maximized="0"
-     inkscape:window-y="176"
+     inkscape:window-y="121"
      inkscape:window-x="251"
      inkscape:window-height="852"
      inkscape:window-width="1429"
@@ -262,22 +170,30 @@
      showgrid="true"
      inkscape:current-layer="layer1"
      inkscape:document-units="px"
-     inkscape:cy="3.9493177"
-     inkscape:cx="-8.4549523"
-     inkscape:zoom="16"
+     inkscape:cy="5.1875"
+     inkscape:cx="5.8125"
+     inkscape:zoom="32"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        snapvisiblegridlinesonly="true"
        enabled="true"
        visible="true"
        empspacing="5"
        id="grid26727"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata25495">
@@ -319,54 +235,6 @@
     <g
        transform="translate(14,-11.1875)"
        id="g6432">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1"
-         d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         style="fill:url(#linearGradient6323);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1-8"
-         d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         style="fill:url(#linearGradient5084-3);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-7"
-         d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-         style="fill:url(#linearGradient5086-8);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-6"
-         d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient5082-1);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-1"
-         d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient5078-8);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-89"
-         d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         style="fill:url(#linearGradient5076-5);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-2"
-         d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-         style="fill:url(#linearGradient5074-2);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-79"
-         d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         style="fill:url(#linearGradient5088-1);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
       <g
          transform="translate(-5.536708,-5.6240351)"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/newprj_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/newprj_wiz.svg
@@ -1,19 +1,19 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    sodipodi:docname="newprj_wiz.svg"
-   inkscape:version="1.0rc1 (09960d6, 2020-04-09)"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    version="1.1"
    id="svg2"
    height="16"
-   width="16">
+   width="16"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -64,18 +64,6 @@
          id="stop3965" />
     </linearGradient>
     <linearGradient
-       id="linearGradient5068"
-       inkscape:collect="always">
-      <stop
-         id="stop5070"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5072"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
        id="linearGradient6281-8-0-1-6">
       <stop
          style="stop-color:#f7f9fb;stop-opacity:1"
@@ -86,18 +74,6 @@
          offset="1"
          id="stop6285-5-0-9-7" />
     </linearGradient>
-    <filter
-       height="1.4800004"
-       y="-0.24000018"
-       width="1.4799996"
-       x="-0.23999982"
-       id="filter8410"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur8412"
-         stdDeviation="1.4653611"
-         inkscape:collect="always" />
-    </filter>
     <linearGradient
        y2="6.000001"
        x2="14"
@@ -139,10 +115,10 @@
        xlink:href="#linearGradient4838"
        inkscape:collect="always" />
     <filter
-       height="1.7548983"
-       y="-0.37744917"
-       width="1.2751431"
-       x="-0.13757156"
+       height="1.859996"
+       y="-0.42999801"
+       width="1.6303747"
+       x="-0.31518737"
        id="filter4929-7"
        inkscape:collect="always">
       <feGaussianBlur
@@ -265,10 +241,10 @@
     </mask>
     <filter
        color-interpolation-filters="sRGB"
-       height="1.7548983"
-       y="-0.37744918"
-       width="1.2751431"
-       x="-0.13757156"
+       height="1.859996"
+       y="-0.42999801"
+       width="1.6303747"
+       x="-0.31518737"
        id="filter4929-9"
        inkscape:collect="always">
       <feGaussianBlur
@@ -603,10 +579,10 @@
     </mask>
     <filter
        color-interpolation-filters="sRGB"
-       height="1.7548983"
-       y="-0.37744918"
-       width="1.2751431"
-       x="-0.13757156"
+       height="1.859996"
+       y="-0.42999801"
+       width="1.6303747"
+       x="-0.31518737"
        id="filter4929-5"
        inkscape:collect="always">
       <feGaussianBlur
@@ -708,98 +684,6 @@
         </g>
       </g>
     </mask>
-    <filter
-       inkscape:collect="always"
-       id="filter17488"
-       x="-0.26986725"
-       width="1.5397345"
-       y="-0.13503321"
-       height="1.2700664">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.42649235"
-         id="feGaussianBlur17490" />
-    </filter>
-    <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6323-7-1-1"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       id="linearGradient5084-3-3-2-6"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       id="linearGradient5086-8-0-8-5"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       id="linearGradient5082-1-0-8-1"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       id="linearGradient5078-8-2-1-4"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       id="linearGradient5076-5-2-9-8"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3500-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)"
-       x1="12"
-       y1="1038.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       id="linearGradient5088-1-4-8-6"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
     <linearGradient
        y2="374.21222"
        x2="538.00562"
@@ -824,30 +708,38 @@
   <sodipodi:namedview
      inkscape:document-rotation="0"
      inkscape:snap-global="false"
-     inkscape:window-maximized="0"
-     inkscape:window-y="478"
-     inkscape:window-x="472"
-     inkscape:window-height="936"
-     inkscape:window-width="1319"
+     inkscape:window-maximized="1"
+     inkscape:window-y="-9"
+     inkscape:window-x="-9"
+     inkscape:window-height="991"
+     inkscape:window-width="1920"
      showgrid="true"
      inkscape:current-layer="layer1-9"
      inkscape:document-units="px"
-     inkscape:cy="12.078655"
-     inkscape:cx="1.8405742"
+     inkscape:cy="12.03125"
+     inkscape:cx="1.78125"
      inkscape:zoom="16"
      inkscape:pageshadow="2"
      inkscape:pageopacity="0.0"
      borderopacity="1.0"
      bordercolor="#666666"
      pagecolor="#ffffff"
-     id="base">
+     id="base"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        snapvisiblegridlinesonly="true"
        enabled="true"
        visible="true"
        empspacing="5"
        id="grid3947"
-       type="xygrid" />
+       type="xygrid"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -879,16 +771,6 @@
            id="layer1-9"
            style="display:inline"
            transform="matrix(3.0279299,0,0,3.0279299,436.08097,-2727.2832)">
-          <g
-             transform="translate(0.696415,25.515546)"
-             style="display:inline"
-             id="g7590-7"
-             mask="url(#mask17098)" />
-          <g
-             transform="matrix(0.40514455,0,0,0.40514455,61.307445,630.5533)"
-             style="display:inline"
-             id="g7827-7"
-             mask="url(#mask17064)" />
           <g
              transform="translate(7.5625,-16.375)"
              id="g4695">
@@ -980,83 +862,9 @@
               </g>
             </g>
             <g
-               mask="url(#mask17458)"
-               id="g17455">
-              <path
-                 sodipodi:nodetypes="ssscccssscccscss"
-                 inkscape:connector-curvature="0"
-                 id="path10927-5-7-9-7"
-                 d="m 5.70269,1044.9373 c -0.185041,-0.018 -0.402396,-0.059 -0.576929,-0.1108 -0.270837,-0.079 -0.243851,0.015 -0.243851,-0.8593 0,-0.4579 0.0077,-0.7598 0.01951,-0.7646 0.01072,0 0.0317,0 0.04665,0.013 0.04847,0.037 0.294579,0.1623 0.376062,0.1926 0.186482,0.069 0.46629,0.1032 0.663393,0.083 0.436936,-0.047 0.733026,-0.2945 0.881951,-0.7389 0.120095,-0.3583 0.114052,-0.2194 0.12641,-2.9086 l 0.01137,-2.4738 0.829393,0 0.829395,0 0.0062,2.3061 c 0.0064,2.384 -5.49e-4,2.6629 -0.0777,3.0973 -0.156267,0.8809 -0.598495,1.5436 -1.254122,1.8796 -0.440731,0.2258 -1.0806,0.337 -1.637678,0.2843 z"
-                 style="display:inline;opacity:0.75;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter17488)" />
-            </g>
-            <g
-               mask="url(#mask17030)"
-               id="g8461"
-               transform="translate(-0.888856,-1.9408198)">
-              <g
-                 style="display:inline;fill:#ffffff;stroke:#ffffff"
-                 transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-                 id="g7590-1-0">
-                <path
-                   style="display:inline;opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503387;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter8410)"
-                   d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-                   id="rect6501-1-6-8"
-                   inkscape:connector-curvature="0"
-                   sodipodi:nodetypes="czczczczc" />
-              </g>
-            </g>
-            <g
                transform="translate(14.061309,-9.3891741)"
                id="g6432"
                style="display:inline">
-              <path
-                 sodipodi:nodetypes="ccccc"
-                 inkscape:connector-curvature="0"
-                 id="path5581-1-1"
-                 d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-                 style="display:inline;fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none" />
-              <path
-                 sodipodi:nodetypes="cccccc"
-                 inkscape:connector-curvature="0"
-                 id="path5581-1-1-8"
-                 d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-                 style="display:inline;fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none" />
-              <path
-                 sodipodi:nodetypes="ccccc"
-                 id="path5581-1-1-7"
-                 d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-                 style="display:inline;fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none"
-                 inkscape:connector-curvature="0" />
-              <path
-                 sodipodi:nodetypes="ccccc"
-                 id="path5581-1-1-6-0"
-                 d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-                 style="display:inline;fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none"
-                 inkscape:connector-curvature="0" />
-              <path
-                 sodipodi:nodetypes="ccccc"
-                 id="path5581-1-1-1-1"
-                 d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-                 style="display:inline;fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none"
-                 inkscape:connector-curvature="0" />
-              <path
-                 sodipodi:nodetypes="ccccc"
-                 id="path5581-1-1-89"
-                 d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-                 style="display:inline;fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none"
-                 inkscape:connector-curvature="0" />
-              <path
-                 sodipodi:nodetypes="ccccc"
-                 id="path5581-1-1-2"
-                 d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-                 style="display:inline;fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none"
-                 inkscape:connector-curvature="0" />
-              <path
-                 sodipodi:nodetypes="ccccc"
-                 id="path5581-1-1-79"
-                 d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-                 style="display:inline;fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none"
-                 inkscape:connector-curvature="0" />
               <g
                  transform="translate(-5.536708,-5.6240351)"
                  id="g4514-8"

--- a/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/save_edit.svg
+++ b/org.eclipse.images/eclipse-svg/eclipse.platform.common/bundles/org.eclipse.platform.doc.user/images/save_edit.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="save_edit.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="save_edit.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -147,22 +147,31 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="4.7239926"
-     inkscape:cy="5.7103589"
+     inkscape:cx="4.734375"
+     inkscape:cy="5.703125"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1458"
-     inkscape:window-height="1228"
-     inkscape:window-x="1055"
-     inkscape:window-y="238"
+     inkscape:window-height="1033"
+     inkscape:window-x="444"
+     inkscape:window-y="0"
      inkscape:window-maximized="0"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:snap-global="false">
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3952" />
+       id="grid3952"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -182,9 +191,6 @@
      id="layer1"
      style="display:inline"
      transform="translate(0,-1036.3622)">
-    <g
-       id="g4990"
-       transform="translate(-36.649179,0.40625)" />
     <rect
        style="fill:url(#base-fill-inst);fill-opacity:1;stroke:url(#base-stroke-inst);stroke-opacity:1"
        id="disk-base"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ant.ui/icons/full/obj16/new_ant_project.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ant.ui/icons/full/obj16/new_ant_project.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="new_ant_project.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_ant_project.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <radialGradient
@@ -100,98 +100,6 @@
        y1="5.6525216"
        x2="7.8451643"
        y2="1.0179684" />
-    <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6323-7"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient5068-6-9"
-       inkscape:collect="always">
-      <stop
-         id="stop5070-8-0"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5072-3-6"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       id="linearGradient5084-3-3"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       id="linearGradient5086-8-0"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       id="linearGradient5082-1-0"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       id="linearGradient5078-8-2"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       id="linearGradient5076-5-2"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       id="linearGradient5074-2-1"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       id="linearGradient5088-1-4"
-       xlink:href="#linearGradient5068-6-9"
-       inkscape:collect="always" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9-5-7-9"
@@ -520,21 +428,30 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="16"
-     inkscape:cx="11.999359"
-     inkscape:cy="5.202427"
+     inkscape:cx="11.96875"
+     inkscape:cy="5.15625"
      inkscape:document-units="px"
-     inkscape:current-layer="g5221"
+     inkscape:current-layer="g5354"
      showgrid="true"
-     inkscape:window-width="1241"
-     inkscape:window-height="814"
-     inkscape:window-x="693"
-     inkscape:window-y="519"
-     inkscape:window-maximized="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
      showguides="true"
-     inkscape:guide-bbox="true">
+     inkscape:guide-bbox="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3006" />
+       id="grid3006"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -796,54 +713,6 @@
            style="display:inline"
            id="g6432"
            transform="matrix(0.96522218,0,0,1,23.927802,-10.950662)">
-          <path
-             style="fill:url(#linearGradient6323-7);fill-opacity:1;stroke:none;display:inline"
-             d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-             id="path5581-1-1"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             style="fill:url(#linearGradient5084-3-3);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-             id="path5581-1-1-8"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5086-8-0);fill-opacity:1;stroke:none;display:inline"
-             d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-             id="path5581-1-1-7"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5082-1-0);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-             id="path5581-1-1-6"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5078-8-2);fill-opacity:1;stroke:none;display:inline"
-             d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-             id="path5581-1-1-1"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5076-5-2);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-             id="path5581-1-1-89"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5074-2-1);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-             id="path5581-1-1-2"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5088-1-4);fill-opacity:1;stroke:none;display:inline"
-             d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-             id="path5581-1-1-79"
-             sodipodi:nodetypes="ccccc" />
           <g
              style="display:inline"
              id="g4514"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.compare.win32/icons/full/elcl16/save.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.compare.win32/icons/full/elcl16/save.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.0 r9654"
-   sodipodi:docname="save_edit.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="save.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -146,22 +146,31 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="11.313709"
-     inkscape:cx="5.2524223"
-     inkscape:cy="10.861786"
+     inkscape:cx="5.2591065"
+     inkscape:cy="10.827572"
      inkscape:document-units="px"
-     inkscape:current-layer="g4953"
+     inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1208"
      inkscape:window-height="913"
      inkscape:window-x="259"
-     inkscape:window-y="299"
+     inkscape:window-y="60"
      inkscape:window-maximized="0"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:snap-global="false">
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3952" />
+       id="grid3952"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -181,9 +190,6 @@
      id="layer1"
      style="display:inline"
      transform="translate(0,-1036.3622)">
-    <g
-       id="g4990"
-       transform="translate(-36.649179,0.40625)" />
     <rect
        style="fill:url(#linearGradient4899);fill-opacity:1;stroke:url(#linearGradient4744);stroke-opacity:1"
        id="rect3968"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.debug.ui/icons/full/elcl16/new_con.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.debug.ui/icons/full/elcl16/new_con.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="newfile_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_con.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -198,16 +198,6 @@
        gradientTransform="translate(-0.0078125,0.015625)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3050"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,1036.3778)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4863"
        id="linearGradient3052"
        gradientUnits="userSpaceOnUse"
@@ -225,76 +215,6 @@
        y1="4.8437853"
        x2="0.9375"
        y2="7.549418" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3056"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3058"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3062"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3064"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(1.0377888,0.49256596)"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3066"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="12"
-       y1="1038.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3068"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9"
@@ -411,22 +331,31 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="45.602194"
-     inkscape:cx="7.8553189"
-     inkscape:cy="14.94495"
+     inkscape:cx="7.8395351"
+     inkscape:cy="6.6992391"
      inkscape:document-units="px"
      inkscape:current-layer="g3038"
      showgrid="true"
-     inkscape:window-width="1245"
-     inkscape:window-height="804"
-     inkscape:window-x="929"
-     inkscape:window-y="343"
-     inkscape:window-maximized="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:snap-global="true">
+     inkscape:snap-global="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3971" />
+       id="grid3971"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -461,54 +390,6 @@
     <g
        id="g3038"
        transform="matrix(1.1954268,0,0,1.1954268,-2.4071696,-204.29183)">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1"
-         d="m 8,1043.3622 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         style="fill:url(#linearGradient3050);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1-8"
-         d="m 10,1045.3622 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         style="fill:url(#linearGradient3056);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-7"
-         d="m 13.523438,1041.8778 0,2 0.476562,0.4844 0,-2 z"
-         style="fill:url(#linearGradient3058);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-6"
-         d="m 10,1043.3622 0,2 1.492188,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient3060);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-1"
-         d="m 8,1038.3622 0,5 1.4609376,-1.4844 1.7544454,-2 z"
-         style="fill:url(#linearGradient3062);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-89"
-         d="m 11.045601,1038.8392 -1.9999997,0 1.4609377,1.5156 2.03125,0 z"
-         style="fill:url(#linearGradient3064);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-2"
-         d="m 10,1038.3622 0,0 1.503907,1.5273 0,-1.5156 z"
-         style="fill:url(#linearGradient3066);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-79"
-         d="m 13.996095,1041.8778 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         style="fill:url(#linearGradient3068);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
       <g
          style="display:inline"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.junit/icons/full/etool16/new_testcase.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.junit/icons/full/etool16/new_testcase.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="test.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_testcase.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -114,18 +114,6 @@
          id="path8467"
          inkscape:connector-curvature="0" />
     </mask>
-    <filter
-       inkscape:collect="always"
-       id="filter8410"
-       x="-0.23999982"
-       width="1.4799995"
-       y="-0.24000017"
-       height="1.4800004">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412" />
-    </filter>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -134,25 +122,34 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="40.214286"
-     inkscape:cx="10.000002"
-     inkscape:cy="9"
+     inkscape:zoom="14.217897"
+     inkscape:cx="-6.2245492"
+     inkscape:cy="2.3561853"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="2560"
-     inkscape:window-height="1391"
-     inkscape:window-x="0"
-     inkscape:window-y="1"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
      inkscape:window-maximized="1"
      showguides="true"
      inkscape:guide-bbox="true"
      inkscape:snap-global="false"
      inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="true">
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3999" />
+       id="grid3999"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -162,7 +159,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -256,43 +253,6 @@
        d="m 3.5,1040.3774 0,9.4848 5.5000002,0"
        id="path4185"
        inkscape:connector-curvature="0" />
-    <image
-       y="1036.3622"
-       x="17"
-       id="image4231"
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAfJJREFU
-OI2lkT1ok1EUhp/v3pimGOimXWxAxK4qOOiodqjipkhxEAMGBbW0Hewg7aBUmiCCPxARtIOD2JjB
-QlvsYAcHO3XRQWglERpERWsS0iTfvfc4pETjFwXxwDtc3nOe83M9EeF/Qv1rwUK6t6VjCOD17PBf
-x9i2sx+A1cWLHEkssZDulb7z77wmAGBfX+rPYyqPF/d2g9d4+75l9s4uOXppxUNEeDUzItWakaG5
-lKx8Lki1Zpqq+1ayyZjY8nJDpU2VlyWbjEkIwLoQDjDWAOB+6e6ccGzoPU9u7ADg1LlJnj64AgID
-Y2ueAjBWYS2U6hUACsVPLar7wqHBN9Q2DFLJUd0wDIyt/byBcQonQvHrOuMvbxNSGq00Wmu0p5g8
-PMqjpWkGxws8vLqdROqL1/ILxmmcA4ko7vZfCxzRObhwIE7dF/afft7ihQB8q3EiVE2N3HouAOjp
-ivHhe56erljA2wSEcALlb0VG5ifYojRhFSaiw3SoMLeOX+dyZpxsfIrVt4vs3XPwd4DCCdgORebk
-/eAKApmzUzhp5AYmsE43TOdTKOUDgO5ojI/lPN3RGNbpIMBYjTiolSrEs6NEvDBRHWGr7qTTC3Pz
-RJIzj4eZTzzD2HYApxCEuUQm0B1oeoJgXNsVFDPT6bbFwWgF/ABSFwB6XWQomgAAAABJRU5ErkJg
-gg==
-"
-       style="image-rendering:optimizeSpeed"
-       preserveAspectRatio="none"
-       height="16"
-       width="16" />
-    <g
-       transform="matrix(0.6258371,0,0,0.98852889,3.1169292,8.9685178)"
-       style="display:inline"
-       id="g8461"
-       mask="url(#mask8465)">
-      <g
-         id="g7590-1-0"
-         transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-         style="display:inline;fill:#ffffff;stroke:#ffffff;stroke-width:1.27137804">
-        <path
-           sodipodi:nodetypes="czczczczc"
-           inkscape:connector-curvature="0"
-           id="rect6501-1-6-8"
-           d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-           style="display:inline;opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:7.44396067;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter8410)" />
-      </g>
-    </g>
     <rect
        style="display:inline;fill:url(#radialGradient3091-1-9-6-4);fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3910"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.junit/icons/full/etool16/new_testsuite.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.junit/icons/full/etool16/new_testsuite.svg
@@ -2,23 +2,23 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
    sodipodi:docname="new_testsuite.svg"
    inkscape:export-filename="/Users/d021678/git/images/com.sap.ide.images/png/sap/obj/tsuitefail.png"
    inkscape:export-xdpi="90"
-   inkscape:export-ydpi="90">
+   inkscape:export-ydpi="90"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -149,18 +149,6 @@
          id="path8467"
          inkscape:connector-curvature="0" />
     </mask>
-    <filter
-       inkscape:collect="always"
-       id="filter8410"
-       x="-0.23999982"
-       width="1.4799995"
-       y="-0.24000017"
-       height="1.4800004">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412" />
-    </filter>
   </defs>
   <sodipodi:namedview
      id="base"
@@ -169,26 +157,35 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="70.14107"
-     inkscape:cx="13.371776"
-     inkscape:cy="8.0266811"
+     inkscape:zoom="17.535268"
+     inkscape:cx="8.3545917"
+     inkscape:cy="2.7088267"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="2560"
-     inkscape:window-height="1391"
-     inkscape:window-x="0"
-     inkscape:window-y="1"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
      inkscape:window-maximized="1"
      showguides="false"
      inkscape:guide-bbox="true"
      inkscape:snap-global="false"
      inkscape:snap-bbox="true"
      inkscape:bbox-nodes="true"
-     inkscape:snap-bbox-edge-midpoints="false">
+     inkscape:snap-bbox-edge-midpoints="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3999" />
+       id="grid3999"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -198,7 +195,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -298,38 +295,12 @@
        id="path4278-4-0-3-2-1"
        d="m 12,1045.8622 1,0"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#49a068;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:0.2154696" />
-    <image
-       y="1036.3088"
-       x="17.358791"
-       id="image4285"
-       xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAgJJREFU OI2lkk1IVFEUgL957+1K7IdgIgaHElsWrVq2EUQXtouIqEAh0qDJ/ggKFVzEwCRaWQRFuCgaYcKc EYyiRWHbCoKgxZAmZsZoTea8+3NavOaN2FiLDlzuPfdyvnvux42ICP8T3qvc6X8S9janIuX1k5s7 pfH4+zBnMpuQkq+rDqWNTGYTIiKICBNDDWJNQSaGGsI9x1gHgAtPrzK1OBeCHSe4ZN2GHQDkBupF KQOAUobcYL0AeMq6rNRQXhsjOE6EjdFdZJJxaT3xKDhfytN0bAQikEnGxdPaRVthWS0DMP1tjuj6 Lbx9dg6Amk3b2d2c4kGqBYAD7Vd4ePs8CBy8/CniKeNhBWanZ+l5PgjA9ZZeAPY0JsPnxC7uZ/jS VmQpz/JPzb5DQ0Grmfs9Uij60jp8UgrfVTCKvrx43CUlX0tiPCkfvsyI0kaUNnLrzGYp+VrevLwm IoLnaw9joVj6QX4hD0Csto7VbowJkiN9nxGBr/Mfg+6UCQALM/N0jnXTOdaNsVDNjbYSzlq7wUdS xsVYYbQjXbnNCmu5OZvu497RfpTxAoA2LtmRG2FxNLqNeLyekvEwVrA1DgNNvSH4zuF+jBVKZUBb +6nKt1wR716PSzU3U4t5YrV1+DoAONWKAdZy03a3C2OpPGFtQHU3ox3p347cvwNWu/kzAsAv2pdj zqDjYJsAAAAASUVORK5CYII= "
-       style="image-rendering:optimizeSpeed"
-       preserveAspectRatio="none"
-       height="16"
-       width="16" />
     <path
        sodipodi:nodetypes="cc"
        inkscape:connector-curvature="0"
        id="path4278-4-0-3-7-2"
        d="m 8.9449378,1043.8817 1.023681,0"
        style="display:inline;fill:none;fill-rule:evenodd;stroke:#49a068;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:0.2154696" />
-    <g
-       transform="matrix(0.88487044,0,0,0.87438018,0.92690317,130.76958)"
-       style="display:inline;fill:#89bc93"
-       id="g8461"
-       mask="url(#mask8465)">
-      <g
-         id="g7590-1-0"
-         transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-         style="display:inline;fill:#89bc93;stroke:#ffffff;stroke-width:1.136868">
-        <path
-           sodipodi:nodetypes="czczczczc"
-           inkscape:connector-curvature="0"
-           id="rect6501-1-6-8"
-           d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-           style="display:inline;opacity:0.85;fill:#89bc93;stroke:#ffffff;stroke-width:6.6564002;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter8410)" />
-      </g>
-    </g>
     <rect
        style="display:inline;fill:url(#radialGradient3091-1-9-6-4);fill-opacity:1;stroke:#a27d18;stroke-width:1.03243756;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
        id="rect3910"
@@ -345,12 +316,4 @@
        d="m 12.022885,1038.3817 1.001133,0 0,2 1.986639,0 0,0.9593 -1.986639,0 0,2.0407 -1.001133,0 0,-2.0407 -1.98664,0 0,-0.9593 1.98664,0 z"
        style="display:inline;fill:url(#linearGradient3093-5-2-7-0);fill-opacity:1;stroke:none" />
   </g>
-  <g
-     inkscape:groupmode="layer"
-     id="layer2"
-     inkscape:label="Layer 2" />
-  <g
-     inkscape:groupmode="layer"
-     id="layer3"
-     inkscape:label="Layer 3" />
 </svg>

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newclass_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newclass_wiz.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="newclass_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newclass_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -300,19 +300,6 @@
        y1="1037.4661"
        x2="-15.945988"
        y2="1023.2569" />
-    <filter
-       color-interpolation-filters="sRGB"
-       height="1.4800004"
-       y="-0.24000017"
-       width="1.4799995"
-       x="-0.23999982"
-       id="filter8410-9-1"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur8412-2-6"
-         stdDeviation="1.4653611"
-         inkscape:collect="always" />
-    </filter>
     <mask
        maskUnits="userSpaceOnUse"
        id="mask10620">
@@ -541,86 +528,6 @@
          offset="1"
          style="stop-color:#ffd680;stop-opacity:1" />
     </linearGradient>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3329"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3331"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.58744691,-15.015625,440.09687)"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3333"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3335"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="matrix(1,0,0,0.58744691,-15.015625,440.09687)"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3337"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3339"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3341"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)"
-       x1="12"
-       y1="1038.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3343"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9-5-7-9-7-3"
@@ -690,20 +597,29 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="1.725473"
-     inkscape:cy="9.1136036"
+     inkscape:cx="1.71875"
+     inkscape:cy="9.109375"
      inkscape:document-units="px"
-     inkscape:current-layer="g6432"
+     inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1419"
      inkscape:window-height="939"
      inkscape:window-x="216"
-     inkscape:window-y="490"
+     inkscape:window-y="34"
      inkscape:window-maximized="0"
-     inkscape:snap-global="false">
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid10382" />
+       id="grid10382"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -724,50 +640,13 @@
      style="display:inline"
      transform="translate(0,-1036.3622)">
     <g
-       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
-       style="display:inline"
-       id="g11331-3-1-1">
-      <g
-         id="g13408-8"
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
-    </g>
-    <g
        transform="matrix(-1,0,0,1,16.12959,8.0140628)"
        style="display:inline"
        id="g6124-3">
       <g
          transform="scale(-1,1)"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
-         id="text6430" />
-      <g
-         transform="scale(-1,1)"
          style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
          id="g6438">
-        <g
-           id="g8461-0"
-           mask="url(#mask10620)"
-           style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
-           transform="translate(-16.999387,-10.043212)">
-          <g
-             id="g7590-1-0-4"
-             transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-             style="fill:#ffffff;stroke:#ffffff;display:inline">
-            <path
-               sodipodi:nodetypes="czczczczc"
-               inkscape:connector-curvature="0"
-               id="rect6501-1-6-8-6"
-               d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-               style="opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503387;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;filter:url(#filter8410-9-1)" />
-          </g>
-        </g>
-        <g
-           id="g10525"
-           transform="translate(0.0625,0.625)">
-          <g
-             style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
-             transform="matrix(0.51237963,0,0,0.51237963,4.5386346,504.16212)"
-             id="g7590-1-9" />
-        </g>
         <g
            transform="translate(-16.12959,-8.0140624)"
            style="display:inline"
@@ -776,10 +655,6 @@
              transform="matrix(-1,0,0,1,16.12959,8.0140628)"
              style="display:inline"
              id="g6124-3-3">
-            <g
-               transform="scale(-1,1)"
-               style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none"
-               id="text6430-8" />
             <g
                transform="scale(-1,1)"
                style="font-style:normal;font-weight:normal;font-size:13.58917427px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;display:inline;fill:#ffffff;fill-opacity:1;stroke:none"
@@ -791,10 +666,6 @@
                  style="display:inline;fill:url(#linearGradient3929-5-7);fill-opacity:1;stroke:#14733c;stroke-width:1.49227178;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1"
                  id="path10796-2-6-2"
                  transform="matrix(0.66884336,0,0,0.67139756,-267.18268,722.47026)" />
-              <g
-                 transform="scale(0.94400511,1.0593163)"
-                 style="font-size:15.56941891px;font-family:Sans;fill:#ffffff"
-                 id="text3782" />
             </g>
           </g>
           <path
@@ -809,54 +680,6 @@
          style="display:inline"
          id="g6432"
          transform="matrix(-1,0,0,1,1.137506,-18.25614)">
-        <path
-           style="fill:url(#linearGradient3329);fill-opacity:1;stroke:none;display:inline"
-           d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-           id="path5581-1-1"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           style="display:inline;fill:url(#linearGradient3331);fill-opacity:1;stroke:none"
-           d="m -5.007813,1054.1825 4,0 0,-0.5874 -0.476562,-0.2846 -2.03125,0 z"
-           id="path5581-1-1-8"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3333);fill-opacity:1;stroke:none;display:inline"
-           d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-           id="path5581-1-1-7"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="display:inline;fill:url(#linearGradient3335);fill-opacity:1;stroke:none"
-           d="m -5.007813,1053.0076 0,1.1749 1.492188,-0.872 0,-1.1749 z"
-           id="path5581-1-1-6"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3337);fill-opacity:1;stroke:none;display:inline"
-           d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-           id="path5581-1-1-1"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3339);fill-opacity:1;stroke:none;display:inline"
-           d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-           id="path5581-1-1-89"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3341);fill-opacity:1;stroke:none;display:inline"
-           d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-           id="path5581-1-1-2"
-           sodipodi:nodetypes="ccccc" />
-        <path
-           inkscape:connector-curvature="0"
-           style="fill:url(#linearGradient3343);fill-opacity:1;stroke:none;display:inline"
-           d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-           id="path5581-1-1-79"
-           sodipodi:nodetypes="ccccc" />
         <g
            style="display:inline"
            id="g4514"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newenum_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newenum_wiz.svg
@@ -187,10 +187,10 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="45.254834"
-     inkscape:cx="8.2090678"
-     inkscape:cy="6.1319416"
+     inkscape:cx="8.2311649"
+     inkscape:cy="6.1098445"
      inkscape:document-units="px"
-     inkscape:current-layer="g6124-3"
+     inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1920"
      inkscape:window-height="991"
@@ -230,21 +230,9 @@
      style="display:inline"
      transform="translate(0,-1036.3622)">
     <g
-       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
-       style="display:inline"
-       id="g11331-3-1-1">
-      <g
-         id="g13408-8"
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
-    </g>
-    <g
        transform="matrix(-1,0,0,1,16.12959,8.0140628)"
        style="display:inline"
        id="g6124-3">
-      <g
-         transform="scale(-1,1)"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
-         id="text6430" />
       <g
          transform="scale(-1,1)"
          style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
@@ -291,9 +279,6 @@
              id="rect7222-7-2-5"
              style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans" />
         </g>
-        <g
-           id="g10525"
-           transform="translate(0.25,0.6875)" />
         <g
            style="display:inline"
            id="g6432"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newint_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newint_wiz.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="newint_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newint_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -121,19 +121,6 @@
        y1="1037.4661"
        x2="-15.945988"
        y2="1023.2569" />
-    <filter
-       color-interpolation-filters="sRGB"
-       height="1.4800004"
-       y="-0.24000017"
-       width="1.4799995"
-       x="-0.23999982"
-       id="filter8410-9-1"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur8412-2-6"
-         stdDeviation="1.4653611"
-         inkscape:collect="always" />
-    </filter>
     <mask
        maskUnits="userSpaceOnUse"
        id="mask10620">
@@ -148,106 +135,6 @@
          d="m 398.75,468.23718 a 10.625,10.625 0 1 1 -21.25,0 10.625,10.625 0 1 1 21.25,0 z"
          transform="matrix(0.55482947,0,0,0.55482947,-206.96039,787.08655)" />
     </mask>
-    <filter
-       inkscape:collect="always"
-       id="filter8047">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.13789128"
-         id="feGaussianBlur8049" />
-    </filter>
-    <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6323-7-1-1"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient5068-6-9-4-9"
-       inkscape:collect="always">
-      <stop
-         id="stop5070-8-0-4-9"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5072-3-6-1-7"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       id="linearGradient5084-3-3-2-6"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       id="linearGradient5086-8-0-8-5"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       id="linearGradient5082-1-0-8-1"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       id="linearGradient5078-8-2-1-4"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       id="linearGradient5076-5-2-9-8"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3500-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)"
-       x1="12"
-       y1="1038.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       id="linearGradient5088-1-4-8-6"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9-5-7-9-7-3"
@@ -342,20 +229,29 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="22.627416"
-     inkscape:cx="15.763713"
-     inkscape:cy="7.9239226"
+     inkscape:cx="15.755224"
+     inkscape:cy="7.9328546"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="925"
-     inkscape:window-height="847"
-     inkscape:window-x="1543"
-     inkscape:window-y="689"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid10382" />
+       id="grid10382"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -375,14 +271,6 @@
      id="layer1"
      style="display:inline"
      transform="translate(0,-1036.3622)">
-    <g
-       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
-       style="display:inline"
-       id="g11331-3-1-1">
-      <g
-         id="g13408-8"
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
-    </g>
     <g
        id="g3093"
        transform="translate(-16.440233,9.5017478)">
@@ -407,54 +295,6 @@
        style="display:inline"
        id="g6432"
        transform="translate(15.023334,-10.242077)">
-      <path
-         style="fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none;display:inline"
-         d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         id="path5581-1-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         id="path5581-1-1-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none;display:inline"
-         d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-         id="path5581-1-1-7"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-         id="path5581-1-1-6"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none;display:inline"
-         d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-         id="path5581-1-1-1"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         id="path5581-1-1-89"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-         id="path5581-1-1-2"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none;display:inline"
-         d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         id="path5581-1-1-79"
-         sodipodi:nodetypes="ccccc" />
       <g
          style="display:inline"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newjworkingSet_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newjworkingSet_wiz.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.5 r10040"
-   sodipodi:docname="newjworkingSet_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newjworkingSet_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -145,19 +145,6 @@
            style="fill:#ffffff;stroke:#ffffff;stroke-width:1.24123943;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
       </g>
     </mask>
-    <filter
-       color-interpolation-filters="sRGB"
-       inkscape:collect="always"
-       id="filter27875"
-       x="-0.17175916"
-       width="1.3435183"
-       y="-0.18907148"
-       height="1.378143">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.70956165"
-         id="feGaussianBlur27877" />
-    </filter>
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient3967"
@@ -311,15 +298,6 @@
         </g>
       </g>
     </mask>
-    <filter
-       color-interpolation-filters="sRGB"
-       inkscape:collect="always"
-       id="filter27488">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.28131546"
-         id="feGaussianBlur27490" />
-    </filter>
     <mask
        id="mask17098-7"
        maskUnits="userSpaceOnUse">
@@ -438,10 +416,10 @@
     <filter
        inkscape:collect="always"
        id="filter4929-9-0"
-       x="-0.13757156"
-       width="1.2751431"
-       y="-0.37744918"
-       height="1.7548983"
+       x="-0.31518737"
+       width="1.6303747"
+       y="-0.42999801"
+       height="1.859996"
        color-interpolation-filters="sRGB">
       <feGaussianBlur
          inkscape:collect="always"
@@ -553,42 +531,6 @@
            style="fill:#ffffff;fill-opacity:1;display:inline" />
       </g>
     </mask>
-    <filter
-       color-interpolation-filters="sRGB"
-       inkscape:collect="always"
-       id="filter7474-3-2-7-6">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.11526932"
-         id="feGaussianBlur7476-5-5-6-7" />
-    </filter>
-    <filter
-       color-interpolation-filters="sRGB"
-       inkscape:collect="always"
-       id="filter7486-6-6-5-5">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.11526932"
-         id="feGaussianBlur7488-95-0-1-3" />
-    </filter>
-    <filter
-       color-interpolation-filters="sRGB"
-       inkscape:collect="always"
-       id="filter7478-9-8-2-9">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.11526932"
-         id="feGaussianBlur7480-8-8-9-3" />
-    </filter>
-    <filter
-       color-interpolation-filters="sRGB"
-       inkscape:collect="always"
-       id="filter7482-8-1-5-8">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="0.11526932"
-         id="feGaussianBlur7484-3-5-6-9" />
-    </filter>
     <mask
        id="mask17098"
        maskUnits="userSpaceOnUse">
@@ -707,10 +649,10 @@
     <filter
        inkscape:collect="always"
        id="filter4929-9"
-       x="-0.13757156"
-       width="1.2751431"
-       y="-0.37744918"
-       height="1.7548983"
+       x="-0.31518737"
+       width="1.6303747"
+       y="-0.42999801"
+       height="1.859996"
        color-interpolation-filters="sRGB">
       <feGaussianBlur
          inkscape:collect="always"
@@ -912,98 +854,6 @@
        xlink:href="#linearGradient3955-64"
        inkscape:collect="always" />
     <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6323-7-1-1"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient5068-6-9-4-9"
-       inkscape:collect="always">
-      <stop
-         id="stop5070-8-0-4-9"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5072-3-6-1-7"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       id="linearGradient5084-3-3-2-6"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       id="linearGradient5086-8-0-8-5"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       id="linearGradient5082-1-0-8-1"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       id="linearGradient5078-8-2-1-4"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       id="linearGradient5076-5-2-9-8"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       id="linearGradient3500-5"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)"
-       x1="12"
-       y1="1038.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       id="linearGradient5088-1-4-8-6"
-       xlink:href="#linearGradient5068-6-9-4-9"
-       inkscape:collect="always" />
-    <linearGradient
        id="linearGradient4528-9-5-7-9-7-3">
       <stop
          style="stop-color:#e0c576;stop-opacity:1;"
@@ -1055,24 +905,32 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="31.678384"
-     inkscape:cx="13.622407"
-     inkscape:cy="9.0078935"
+     inkscape:cx="13.621276"
+     inkscape:cy="8.9808874"
      inkscape:document-units="px"
-     inkscape:current-layer="g4522"
+     inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="960"
-     inkscape:window-height="1028"
-     inkscape:window-x="960"
-     inkscape:window-y="24"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid2985"
        empspacing="5"
        visible="true"
        enabled="true"
-       snapvisiblegridlinesonly="true" />
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -1115,34 +973,6 @@
          style="fill:none;stroke:url(#linearGradient19045);stroke-width:1.24123943;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     </g>
     <g
-       style="display:inline"
-       id="g27855"
-       mask="url(#mask27861)">
-      <g
-         style="opacity:0.75;fill:#ffffff;stroke:#ffffff;stroke-width:2.48247886;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter27875)"
-         transform="matrix(0.80564634,0,0,0.80564634,0.02727398,204.27398)"
-         id="g18690-04">
-        <path
-           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.48247886;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline"
-           d="m 7.384675,1041.8573 2.282522,0 c 0.480278,0 0.866929,0.3866 0.866929,0.8669 l 0,3.7566 c 0,0.4802 -0.386651,0.8669 -0.866929,0.8669 l -2.282522,0 c -0.480279,0 -0.866929,-0.3867 -0.866929,-0.8669 l 0,-3.7566 c 0,-0.4803 0.38665,-0.8669 0.866929,-0.8669 z"
-           id="rect13693-3-9"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="sssssssss" />
-        <path
-           style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2.48247886;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0"
-           d="m 8.2786681,1043.8847 6.3593049,0 c 0.457329,0 0.825504,0.3683 0.825504,0.8256 l 0,5.3284 c 0,0.4574 -0.368172,0.826 -0.825504,0.8255 l -8.2637361,-0.01 c -0.457332,-6e-4 -0.8255033,-0.3681 -0.8255033,-0.8255 l 0,-5.3221 c 0,-0.4572 0.3541007,-0.8264 0.8255033,-0.8255 z"
-           id="rect13693-67"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cssssssssc" />
-        <path
-           style="fill:#ffffff;stroke:#ffffff;stroke-width:2.48247886;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-           d="m 5.997164,1043.8894 5.698634,0"
-           id="path13797-2"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="cc" />
-      </g>
-    </g>
-    <g
        id="g18690"
        transform="matrix(0.80564634,0,0,0.80564634,0.027274,204.87665)"
        style="stroke-width:1.24123943;stroke-miterlimit:4;stroke-dasharray:none;display:inline">
@@ -1165,86 +995,6 @@
          d="m 5.997164,1043.8894 5.698634,0"
          style="fill:none;stroke:url(#linearGradient18677);stroke-width:1.24123943;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none" />
     </g>
-    <g
-       id="g27468"
-       style="opacity:0.75;fill:#ffffff;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter27488)"
-       mask="url(#mask27659)">
-      <g
-         transform="translate(6.1660514,12.623271)"
-         inkscape:label="Layer 1"
-         id="layer1-3-6"
-         style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;display:inline">
-        <g
-           transform="translate(0.696415,25.515546)"
-           style="fill:#ffffff;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;display:inline"
-           id="g7590-7-4"
-           mask="url(#mask17098-7)" />
-        <g
-           transform="matrix(0.40514455,0,0,0.40514455,61.307445,630.5533)"
-           style="fill:#ffffff;stroke:#ffffff;stroke-width:2.4682548;stroke-miterlimit:4;stroke-dasharray:none;display:inline"
-           id="g7827-7-4"
-           mask="url(#mask17064-0)" />
-        <g
-           style="fill:#ffffff;stroke:#ffffff;stroke-width:1.95167792;stroke-miterlimit:4;stroke-dasharray:none;display:inline"
-           transform="matrix(0.51237963,0,0,0.51237963,14.729972,499.35611)"
-           id="g7590-1-2">
-          <path
-             style="opacity:0.85;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.95167792;stroke-miterlimit:4;stroke-dasharray:none;display:inline"
-             d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-             id="rect6501-7-2"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="czczczczc" />
-          <path
-             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.95167792;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter7474-3-2-7-6)"
-             d="m -16.369192,1024.5153 c 0,0 -0.626195,2.2024 -2.093572,3.6698 -1.467379,1.4674 -3.66991,2.0937 -3.66991,2.0937 l 5.763482,0 0,-5.7635 z"
-             id="rect7280-61-7"
-             inkscape:connector-curvature="0" />
-          <path
-             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.95167792;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter7486-6-6-5-5)"
-             d="m -16.244192,1024.5153 0,5.7635 5.763482,0 c 0,0 -2.165582,-0.5894 -3.66991,-2.0937 -1.504327,-1.5043 -2.093572,-3.6698 -2.093572,-3.6698 z"
-             id="rect7280-8-7-8"
-             inkscape:connector-curvature="0" />
-          <path
-             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.95167792;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter7478-9-8-2-9)"
-             d="m -22.132674,1030.4036 c 0,0 2.104004,0.5276 3.66991,2.0936 1.565905,1.5659 2.093572,3.6698 2.093572,3.6698 l 0,-5.7634 -5.763482,0 z"
-             id="rect7280-5-3-2"
-             inkscape:connector-curvature="0" />
-          <path
-             style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1.95167792;stroke-miterlimit:4;stroke-dasharray:none;display:inline;filter:url(#filter7482-8-1-5-8)"
-             d="m -16.244192,1030.4036 0,5.7634 c 0,0 0.576934,-2.1532 2.093572,-3.6698 1.516639,-1.5167 3.66991,-2.0936 3.66991,-2.0936 l -5.763482,0 z"
-             id="rect7280-6-0-3"
-             inkscape:connector-curvature="0" />
-          <path
-             style="fill:#ffffff;stroke:#ffffff;stroke-width:1.95167792;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none"
-             d="m -22.353552,1030.3411 12.09375,0"
-             id="path7490-0-1"
-             inkscape:connector-curvature="0" />
-          <path
-             style="fill:#ffffff;stroke:#ffffff;stroke-width:1.95167792;stroke-linecap:round;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
-             d="m -16.306677,1024.2942 0,12.0938"
-             id="path7490-1-2-3"
-             inkscape:connector-curvature="0" />
-          <path
-             style="opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:1.95167792;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
-             d="m -16.30668,1023.3378 c 0,0 0.72145,2.6331 2.545823,4.4575 1.824373,1.8243 4.4575209,2.5458 4.4575209,2.5458 0,0 -2.6182109,0.7065 -4.4575149,2.5458 -1.839303,1.8394 -2.545822,4.4575 -2.545822,4.4575 0,0 -0.646772,-2.5584 -2.545824,-4.4575 -1.899051,-1.8991 -4.457521,-2.5458 -4.457521,-2.5458 0,0 2.67796,-0.7663 4.457521,-2.5458 1.779562,-1.7796 2.545817,-4.4575 2.545817,-4.4575 z"
-             id="rect6501-1-6-8"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="czczczczc" />
-        </g>
-        <path
-           style="opacity:0.85;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:1;stroke-miterlimit:4;stroke-dasharray:none;display:inline"
-           d="m 6.3747628,1026.1624 c 0,0 0.115337,0.421 0.406999,0.7127 0.291661,0.2916 0.71262,0.4069 0.71262,0.4069 0,0 -0.418571,0.113 -0.712619,0.407 -0.294048,0.2941 -0.406999,0.7126 -0.406999,0.7126 0,0 -0.103399,-0.4089 -0.406999,-0.7126 -0.3036,-0.3036 -0.712621,-0.407 -0.712621,-0.407 0,0 0.428123,-0.1225 0.712621,-0.4069 0.284497,-0.2846 0.406998,-0.7127 0.406998,-0.7127 z"
-           id="rect6501-1-6-1-1"
-           inkscape:connector-curvature="0"
-           sodipodi:nodetypes="czczczczc" />
-      </g>
-      <path
-         sodipodi:nodetypes="ssscccssscccscss"
-         inkscape:connector-curvature="0"
-         id="path10927-5-7-9-2"
-         d="m 2.7391088,1044.328 c -0.1713098,-0.017 -0.3725357,-0.055 -0.5341173,-0.1026 -0.2507392,-0.073 -0.2257557,0.014 -0.2257557,-0.7956 0,-0.4239 0.00713,-0.7034 0.018062,-0.7078 0.00992,0 0.029348,0 0.043188,0.012 0.044873,0.034 0.2727194,0.1503 0.3481559,0.1783 0.1726438,0.064 0.4316883,0.096 0.614165,0.077 0.4045126,-0.044 0.6786309,-0.2727 0.8165047,-0.6841 0.1111832,-0.3317 0.1055887,-0.2031 0.1170296,-2.6928 l 0.010526,-2.2902 0.7678468,0 0.7678487,0 0.00574,2.135 c 0.00593,2.2071 -5.082e-4,2.4653 -0.071934,2.8674 -0.144671,0.8156 -0.5540829,1.4291 -1.1610583,1.7402 -0.408026,0.209 -1.0004127,0.3119 -1.516152,0.2632 z"
-         style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;display:inline" />
-    </g>
     <path
        style="fill:#366c9a;fill-opacity:1;display:inline"
        d="m 2.6609358,1044.328 c -0.203979,-0.017 -0.4435792,-0.055 -0.6359748,-0.1026 -0.2985558,-0.073 -0.2688079,0.014 -0.2688079,-0.7956 0,-0.4239 0.00849,-0.7034 0.021507,-0.7078 0.011812,0 0.034945,0 0.051424,0.012 0.05343,0.034 0.3247277,0.1503 0.4145502,0.1783 0.2055674,0.064 0.5140123,0.096 0.7312878,0.077 0.4816542,-0.044 0.8080476,-0.2727 0.9722143,-0.6841 0.1323861,-0.3317 0.1257247,-0.2031 0.1393474,-2.6928 l 0.012533,-2.2902 0.9142772,0 0.9142794,0 0.00683,2.135 c 0.00706,2.2071 -6.051e-4,2.4653 -0.085652,2.8674 -0.1722602,0.8156 -0.659748,1.4291 -1.3824751,1.7402 -0.4858377,0.209 -1.191194,0.3119 -1.8052861,0.2632 z"
@@ -1255,54 +1005,6 @@
        style="display:inline"
        id="g6432"
        transform="matrix(1,0,0,0.99444149,15.023334,-5.4011909)">
-      <path
-         style="fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none;display:inline"
-         d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         id="path5581-1-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         id="path5581-1-1-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none;display:inline"
-         d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-         id="path5581-1-1-7"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-         id="path5581-1-1-6"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none;display:inline"
-         d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-         id="path5581-1-1-1"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         id="path5581-1-1-89"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-         id="path5581-1-1-2"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none;display:inline"
-         d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         id="path5581-1-1-79"
-         sodipodi:nodetypes="ccccc" />
       <g
          style="display:inline"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newpack_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newpack_wiz.svg
@@ -402,10 +402,10 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="43.562501"
-     inkscape:cx="8.9641318"
-     inkscape:cy="7.4490672"
+     inkscape:cx="8.9870873"
+     inkscape:cy="7.4261117"
      inkscape:document-units="px"
-     inkscape:current-layer="g13862"
+     inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1920"
      inkscape:window-height="991"
@@ -501,20 +501,7 @@
              d="m 398.30108,449.88328 -46.58947,0"
              style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#915323;fill-opacity:1;stroke:url(#linearGradient10544);stroke-width:3.58380508;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;font-family:Sans" />
         </g>
-        <g
-           id="g11331-3"
-           style="display:inline"
-           transform="matrix(0.27903303,0,0,0.27903303,-64.52871,915.34629)" />
       </g>
-      <g
-         id="g14104"
-         transform="matrix(1.1835826,0,0,1.1835826,-72.087418,-81.712528)"
-         style="fill:#ffffff;stroke:#ffffff;display:inline" />
-      <g
-         transform="matrix(1.1835826,0,0,1.1835826,-72.087418,-81.712526)"
-         style="display:inline"
-         id="g6258"
-         mask="none" />
       <g
          style="display:inline"
          id="g6432"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newpackfolder_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newpackfolder_wiz.svg
@@ -446,10 +446,10 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="61.60668"
-     inkscape:cx="8.059191"
+     inkscape:cx="8.075423"
      inkscape:cy="7.4586068"
      inkscape:document-units="px"
-     inkscape:current-layer="g13862"
+     inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1920"
      inkscape:window-height="991"
@@ -517,19 +517,10 @@
            inkscape:connector-curvature="0" />
       </g>
       <g
-         transform="matrix(1.1835826,0,0,1.1835826,-72.087418,-81.712526)"
-         style="display:inline"
-         id="g6258"
-         mask="none" />
-      <g
          transform="matrix(3.5838051,0,0,3.5838051,535.64691,-3346.8434)"
          style="display:inline"
          id="layer1-9"
          inkscape:label="Layer 1">
-        <g
-           id="g11331-3"
-           style="display:inline"
-           transform="matrix(0.27903303,0,0,0.27903303,-64.52871,915.34629)" />
         <g
            id="g11260-4"
            transform="matrix(0.27903303,0,0,0.27903303,-120.09325,915.23237)"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newrecord_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newrecord_wiz.svg
@@ -227,9 +227,9 @@
      inkscape:pageshadow="2"
      inkscape:zoom="45"
      inkscape:cx="3.5"
-     inkscape:cy="5.7"
+     inkscape:cy="5.6777778"
      inkscape:document-units="px"
-     inkscape:current-layer="g6438"
+     inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1920"
      inkscape:window-height="991"
@@ -269,21 +269,9 @@
      style="display:inline"
      transform="translate(0,-1036.3622)">
     <g
-       transform="matrix(0.27903303,0,0,0.27903303,-100.53208,912.07901)"
-       style="display:inline"
-       id="g11331-3-1-1">
-      <g
-         id="g13408-8"
-         style="fill:#737986;fill-opacity:1;stroke:#595e68;stroke-opacity:1" />
-    </g>
-    <g
        transform="matrix(-1,0,0,1,16.12959,8.0140628)"
        style="display:inline"
        id="g6124-3">
-      <g
-         transform="scale(-1,1)"
-         style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;font-family:Sans"
-         id="text6430" />
       <g
          transform="scale(-1,1)"
          style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans"
@@ -320,9 +308,6 @@
              id="rect7222-7-2-5"
              style="font-size:13.58917427px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;font-family:Sans" />
         </g>
-        <g
-           id="g10525"
-           transform="translate(0.25,0.6875)" />
         <g
            style="font-size:13.58917427000000089px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:none;display:inline;filter:url(#filter8104);font-family:Sans;opacity:0.5"
            id="g8046-4"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newsbook_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.jdt.ui/icons/full/etool16/newsbook_wiz.svg
@@ -399,8 +399,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32.000001"
-     inkscape:cx="4.0156248"
-     inkscape:cy="8.7968746"
+     inkscape:cx="4.0156249"
+     inkscape:cy="8.7656247"
      inkscape:document-units="px"
      inkscape:current-layer="layer1-8"
      showgrid="true"
@@ -509,14 +509,6 @@
              d="m -7.584151,1041.8789 0,-2.013"
              style="fill:none;stroke:url(#linearGradient7549);stroke-width:1px;stroke-linecap:round;stroke-linejoin:miter;stroke-opacity:1;display:inline" />
         </g>
-        <g
-           transform="translate(-12.593765,20.531347)"
-           style="display:inline"
-           id="g7590-7" />
-        <g
-           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
-           style="display:inline"
-           id="g7827-7" />
         <g
            style="display:inline"
            id="g6432"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.console/icons/full/elcl16/new_con.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.console/icons/full/elcl16/new_con.svg
@@ -297,14 +297,6 @@
            id="rect3997-9-9"
            d="m 2.500702,1041.8621 12.883511,0 0,2.0053 -12.883511,0 z"
            style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-        <g
-           transform="translate(-12.593765,20.531347)"
-           style="display:inline"
-           id="g7590-7" />
-        <g
-           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
-           style="display:inline"
-           id="g7827-7" />
         <path
            transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
            sodipodi:nodetypes="cc"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.editors/icons/full/etool16/new_untitled_text_file.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.editors/icons/full/etool16/new_untitled_text_file.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="new_untitled_text_file.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_untitled_text_file.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -198,16 +198,6 @@
        gradientTransform="translate(-0.0078125,0.015625)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3050"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,1036.3778)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4863"
        id="linearGradient3052"
        gradientUnits="userSpaceOnUse"
@@ -225,76 +215,6 @@
        y1="4.8437853"
        x2="0.9375"
        y2="7.549418" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3056"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.28286539,0.01565881)"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3058"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3062"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3064"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3066"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="12"
-       y1="1038.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3068"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9"
@@ -484,25 +404,34 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="37.918601"
-     inkscape:cx="4.234025"
-     inkscape:cy="8"
+     inkscape:zoom="26.8125"
+     inkscape:cx="0.76456877"
+     inkscape:cy="6.3589744"
      inkscape:document-units="px"
      inkscape:current-layer="g3038"
      showgrid="true"
-     inkscape:window-width="2002"
-     inkscape:window-height="1103"
-     inkscape:window-x="301"
-     inkscape:window-y="223"
+     inkscape:window-width="1902"
+     inkscape:window-height="1033"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
      inkscape:window-maximized="0"
      showguides="true"
      inkscape:guide-bbox="true"
      inkscape:snap-global="true"
      inkscape:snap-bbox="true"
-     inkscape:bbox-nodes="true">
+     inkscape:bbox-nodes="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3971" />
+       id="grid3971"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -512,7 +441,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -537,54 +466,6 @@
     <g
        id="g3038"
        transform="matrix(1.1954268,0,0,1.1954268,-2.4071696,-204.29183)">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1"
-         d="m 8,1043.3622 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         style="fill:url(#linearGradient3050);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1-8"
-         d="m 9.7249471,1045.3622 3.9999999,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         style="display:inline;fill:url(#linearGradient3056);fill-opacity:1;stroke:none" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-7"
-         d="m 13.523438,1041.8778 0,2 0.476562,0.4844 0,-2 z"
-         style="fill:url(#linearGradient3058);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-6"
-         d="m 10,1043.3622 0,2 1.492188,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient3060);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-1"
-         d="m 8,1038.3622 0,5 1.4609376,-1.4844 1.7544454,-2 z"
-         style="fill:url(#linearGradient3062);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-89"
-         d="m 10,1038.3622 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         style="fill:url(#linearGradient3064);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-2"
-         d="m 10,1038.3622 0,0 1.503907,1.5273 0,-1.5156 z"
-         style="fill:url(#linearGradient3066);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-79"
-         d="m 13.996095,1041.8778 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         style="fill:url(#linearGradient3068);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
       <rect
          style="display:inline;fill:url(#radialGradient3091-1);fill-opacity:1;stroke:#a27d18;stroke-width:0.86365604;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          id="rect3910"
@@ -599,25 +480,6 @@
          id="path5581-5-5"
          d="m 12.051904,1038.6701 0.836522,0 0,1.673 1.651638,0 0,0.8365 -1.651638,0 0,1.6731 -0.836522,0 0,-1.6731 -1.673042,0 0,-0.8365 1.673042,0 z"
          style="display:inline;fill:url(#linearGradient3093-5);fill-opacity:1;stroke:none" />
-      <image
-         y="1037.8335"
-         x="-11.370692"
-         id="image4298"
-         xlink:href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABAAAAAQCAYAAAAf8/9hAAAABHNCSVQICAgIfAhkiAAAAcNJREFU
-OI2lkU9IVFEUh7/73oDUrlZBLQoCizaVQdQyECsJzUURSJEghOGmhVFEIQhSgpsIoqJo0z8arKBo
-0KWbSGzhIohZ6GKioKAx3rx/957TYma01zyD6GzuPXDPdz5+16gq/1Pevw5M327PbCz83swWB3N1
-Nmw5yLqNOyhPD9B57h2lWzu16/xH0wLw29bT0TXZAvhatSw82gWm3jtJeXNzux4dLpsMwDmDqGIw
-gKKAwTD3oJ2eoRcAaG2Rw2efg4Gpia2aBUgBUbhXfM+P5YBv36tUl2vcuPyJJ5PbADg5eJ1ndy+C
-wqmrlayBFQ/nYOD4vsZ2aF56R5Z4OroZrS2SxMqZsc+tGVjxEODh1BxpaokSSxTFhGFCGCdMXKtw
-/8om9p9+m/8LqfNxTuk/1tFIIVtRovSPfWFhvvQXgCiPX8/nGsRRyvhIH5XyLBzozgFIAStw4she
-8koBJ5C61bE/DDxEoFha22D0Qh+p8/IBTjycKL2de3IN6m8UK34+wFofUXg184EoTgiCmJ9BSFAL
-uTTU0wjVYN1aAK0bdB/avfILzVO0mYNixeQDlDZmXt7JKNu0hrh4pTfGx3irY78Aji31c6SOj4sA
-AAAASUVORK5CYII=
-"
-         style="image-rendering:optimizeSpeed"
-         preserveAspectRatio="none"
-         height="13.384341"
-         width="13.384341" />
       <rect
          style="display:inline;fill:url(#linearGradient4867-7);fill-opacity:1;stroke:none"
          id="rect4001-1"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.ide/icons/full/etool16/newfile_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.ide/icons/full/etool16/newfile_wiz.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="newfile_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newfile_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -198,16 +198,6 @@
        gradientTransform="translate(-0.0078125,0.015625)" />
     <linearGradient
        inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3050"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,1036.3778)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
        xlink:href="#linearGradient4863"
        id="linearGradient3052"
        gradientUnits="userSpaceOnUse"
@@ -225,76 +215,6 @@
        y1="4.8437853"
        x2="0.9375"
        y2="7.549418" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3056"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3058"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3060"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3062"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3064"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3066"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="12"
-       y1="1038.3622"
-       x2="10.007812"
-       y2="1038.3466" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient3068"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-0.0078125,0.015625)"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9"
@@ -410,23 +330,32 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="2.0153513"
-     inkscape:cx="-177.20337"
-     inkscape:cy="65.22283"
+     inkscape:zoom="32.245621"
+     inkscape:cx="1.0389008"
+     inkscape:cy="5.1945038"
      inkscape:document-units="px"
      inkscape:current-layer="g3038"
      showgrid="false"
-     inkscape:window-width="1245"
-     inkscape:window-height="804"
-     inkscape:window-x="929"
-     inkscape:window-y="343"
-     inkscape:window-maximized="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:snap-global="true">
+     inkscape:snap-global="true"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3971" />
+       id="grid3971"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="false" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -461,54 +390,6 @@
     <g
        id="g3038"
        transform="matrix(1.1954268,0,0,1.1954268,-2.4071696,-204.29183)">
-      <path
-         sodipodi:nodetypes="ccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1"
-         d="m 8,1043.3622 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         style="fill:url(#linearGradient3050);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="cccccc"
-         inkscape:connector-curvature="0"
-         id="path5581-1-1-8"
-         d="m 10,1045.3622 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         style="fill:url(#linearGradient3056);fill-opacity:1;stroke:none;display:inline" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-7"
-         d="m 13.523438,1041.8778 0,2 0.476562,0.4844 0,-2 z"
-         style="fill:url(#linearGradient3058);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-6"
-         d="m 10,1043.3622 0,2 1.492188,-1.4844 0,-2 z"
-         style="fill:url(#linearGradient3060);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-1"
-         d="m 8,1038.3622 0,5 1.4609376,-1.4844 1.7544454,-2 z"
-         style="fill:url(#linearGradient3062);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-89"
-         d="m 10,1038.3622 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         style="fill:url(#linearGradient3064);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-2"
-         d="m 10,1038.3622 0,0 1.503907,1.5273 0,-1.5156 z"
-         style="fill:url(#linearGradient3066);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
-      <path
-         sodipodi:nodetypes="ccccc"
-         id="path5581-1-1-79"
-         d="m 13.996095,1041.8778 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         style="fill:url(#linearGradient3068);fill-opacity:1;stroke:none;display:inline"
-         inkscape:connector-curvature="0" />
       <g
          style="display:inline"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.ide/icons/full/etool16/newfolder_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.ide/icons/full/etool16/newfolder_wiz.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg25490"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="newfolder_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newfolder_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs25492">
     <linearGradient
@@ -118,88 +118,6 @@
        x2="531.09253"
        y2="371.17883" />
     <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       id="linearGradient5088-1"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient5068-6"
-       inkscape:collect="always">
-      <stop
-         id="stop5070-8"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5072-3"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       id="linearGradient5074-2"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       id="linearGradient5076-5"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       id="linearGradient5078-8"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       id="linearGradient5082-1"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       id="linearGradient5086-8"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       id="linearGradient5084-3"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4823-5"
        id="linearGradient5618-4"
@@ -242,16 +160,6 @@
          offset="1"
          style="stop-color:#997413;stop-opacity:1" />
     </linearGradient>
-    <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6323"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9-5"
@@ -347,24 +255,32 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="16"
-     inkscape:cx="3.5762977"
-     inkscape:cy="3.9493177"
+     inkscape:cx="3.53125"
+     inkscape:cy="3.90625"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:snap-global="false"
-     inkscape:window-width="1429"
-     inkscape:window-height="852"
-     inkscape:window-x="948"
-     inkscape:window-y="685"
-     inkscape:window-maximized="0">
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid26727"
        empspacing="5"
        visible="true"
        enabled="true"
-       snapvisiblegridlinesonly="true" />
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata25495">
@@ -406,54 +322,6 @@
     <g
        id="g6432"
        transform="translate(14,-11.1875)">
-      <path
-         style="fill:url(#linearGradient6323);fill-opacity:1;stroke:none;display:inline"
-         d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         id="path5581-1-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:url(#linearGradient5084-3);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         id="path5581-1-1-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5086-8);fill-opacity:1;stroke:none;display:inline"
-         d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-         id="path5581-1-1-7"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5082-1);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-         id="path5581-1-1-6"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5078-8);fill-opacity:1;stroke:none;display:inline"
-         d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-         id="path5581-1-1-1"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5076-5);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         id="path5581-1-1-89"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5074-2);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-         id="path5581-1-1-2"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5088-1);fill-opacity:1;stroke:none;display:inline"
-         d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         id="path5581-1-1-79"
-         sodipodi:nodetypes="ccccc" />
       <g
          style="display:inline"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.ide/icons/full/etool16/newgroup_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.ide/icons/full/etool16/newgroup_wiz.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg25490"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="newgroup_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newgroup_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs25492">
     <linearGradient
@@ -40,88 +40,6 @@
        y1="396.2229"
        x2="538.00562"
        y2="374.21222" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       id="linearGradient5088-1"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       id="linearGradient5068-6"
-       inkscape:collect="always">
-      <stop
-         id="stop5070-8"
-         offset="0"
-         style="stop-color:#ffffff;stop-opacity:1;" />
-      <stop
-         id="stop5072-3"
-         offset="1"
-         style="stop-color:#ffffff;stop-opacity:0;" />
-    </linearGradient>
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       id="linearGradient5074-2"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1040.3622"
-       x1="10"
-       id="linearGradient5076-5"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       id="linearGradient5078-8"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       id="linearGradient5082-1"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       id="linearGradient5086-8"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       id="linearGradient5084-3"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4823-5"
@@ -165,16 +83,6 @@
          offset="1"
          style="stop-color:#997413;stop-opacity:1" />
     </linearGradient>
-    <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6323"
-       xlink:href="#linearGradient5068-6"
-       inkscape:collect="always" />
     <radialGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4528-9-5"
@@ -227,24 +135,32 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="16"
-     inkscape:cx="3.5762977"
-     inkscape:cy="3.9493177"
+     inkscape:cx="3.5625"
+     inkscape:cy="3.9375"
      inkscape:document-units="px"
      inkscape:current-layer="g6432"
      showgrid="true"
      inkscape:snap-global="false"
      inkscape:window-width="1429"
      inkscape:window-height="852"
-     inkscape:window-x="948"
-     inkscape:window-y="685"
-     inkscape:window-maximized="0">
+     inkscape:window-x="473"
+     inkscape:window-y="121"
+     inkscape:window-maximized="0"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid26727"
        empspacing="5"
        visible="true"
        enabled="true"
-       snapvisiblegridlinesonly="true" />
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata25495">
@@ -286,54 +202,6 @@
     <g
        id="g6432"
        transform="translate(14,-11.1875)">
-      <path
-         style="fill:url(#linearGradient6323);fill-opacity:1;stroke:none;display:inline"
-         d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-         id="path5581-1-1"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         style="fill:url(#linearGradient5084-3);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-         id="path5581-1-1-8"
-         inkscape:connector-curvature="0"
-         sodipodi:nodetypes="cccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5086-8);fill-opacity:1;stroke:none;display:inline"
-         d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-         id="path5581-1-1-7"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5082-1);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-         id="path5581-1-1-6"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5078-8);fill-opacity:1;stroke:none;display:inline"
-         d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-         id="path5581-1-1-1"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5076-5);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-         id="path5581-1-1-89"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5074-2);fill-opacity:1;stroke:none;display:inline"
-         d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-         id="path5581-1-1-2"
-         sodipodi:nodetypes="ccccc" />
-      <path
-         inkscape:connector-curvature="0"
-         style="fill:url(#linearGradient5088-1);fill-opacity:1;stroke:none;display:inline"
-         d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-         id="path5581-1-1-79"
-         sodipodi:nodetypes="ccccc" />
       <g
          style="display:inline"
          id="g4514"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.ide/icons/full/etool16/newprj_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.ide/icons/full/etool16/newprj_wiz.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="newprj_wiz.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="newprj_wiz.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -357,18 +357,6 @@
            style="fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:3.60383272;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;display:inline" />
       </g>
     </mask>
-    <filter
-       inkscape:collect="always"
-       id="filter8410"
-       x="-0.23999982"
-       width="1.4799996"
-       y="-0.24000018"
-       height="1.4800004">
-      <feGaussianBlur
-         inkscape:collect="always"
-         stdDeviation="1.4653611"
-         id="feGaussianBlur8412" />
-    </filter>
     <linearGradient
        id="linearGradient7540-6-33-6-3">
       <stop
@@ -443,10 +431,10 @@
     <filter
        inkscape:collect="always"
        id="filter4929-7"
-       x="-0.13757156"
-       width="1.2751431"
-       y="-0.37744917"
-       height="1.7548983">
+       x="-0.31518737"
+       width="1.6303747"
+       y="-0.42999801"
+       height="1.859996">
       <feGaussianBlur
          inkscape:collect="always"
          stdDeviation="3.5620748"
@@ -568,10 +556,10 @@
     <filter
        inkscape:collect="always"
        id="filter4929-9"
-       x="-0.13757156"
-       width="1.2751431"
-       y="-0.37744918"
-       height="1.7548983"
+       x="-0.31518737"
+       width="1.6303747"
+       y="-0.42999801"
+       height="1.859996"
        color-interpolation-filters="sRGB">
       <feGaussianBlur
          inkscape:collect="always"
@@ -935,10 +923,10 @@
     <filter
        inkscape:collect="always"
        id="filter4929-5"
-       x="-0.13757156"
-       width="1.2751431"
-       y="-0.37744918"
-       height="1.7548983"
+       x="-0.31518737"
+       width="1.6303747"
+       y="-0.42999801"
+       height="1.859996"
        color-interpolation-filters="sRGB">
       <feGaussianBlur
          inkscape:collect="always"
@@ -1039,98 +1027,6 @@
         </g>
       </g>
     </mask>
-    <filter
-       height="1.2700664"
-       y="-0.13503321"
-       width="1.5397345"
-       x="-0.26986725"
-       id="filter17488"
-       inkscape:collect="always">
-      <feGaussianBlur
-         id="feGaussianBlur17490"
-         stdDeviation="0.42649235"
-         inkscape:collect="always" />
-    </filter>
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient6323-7-1-1"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       x1="10"
-       y1="5"
-       x2="10.007812"
-       y2="6.9843998" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient5084-3-3-2-6"
-       x1="12"
-       y1="1043.3622"
-       x2="12"
-       y2="1045.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient5086-8-0-8-5"
-       x1="13"
-       y1="1043.3622"
-       x2="15.007812"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient5082-1-0-8-1"
-       x1="12"
-       y1="1042.3622"
-       x2="10.007812"
-       y2="1042.3622"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient5078-8-2-1-4"
-       x1="10"
-       y1="1041.3622"
-       x2="8.0078125"
-       y2="1041.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient5076-5-2-9-8"
-       x1="10"
-       y1="1040.3622"
-       x2="10.007812"
-       y2="1038.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
-    <linearGradient
-       y2="1038.3466"
-       x2="10.007812"
-       y1="1038.3622"
-       x1="12"
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient3500-5"
-       xlink:href="#linearGradient5068"
-       inkscape:collect="always" />
-    <linearGradient
-       inkscape:collect="always"
-       xlink:href="#linearGradient5068"
-       id="linearGradient5088-1-4-8-6"
-       x1="14"
-       y1="1041.3622"
-       x2="14"
-       y2="1043.3466"
-       gradientUnits="userSpaceOnUse"
-       gradientTransform="translate(-15.015625,10.2734)" />
     <linearGradient
        inkscape:collect="always"
        xlink:href="#linearGradient4762"
@@ -1160,24 +1056,32 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="16"
-     inkscape:cx="1.8405742"
-     inkscape:cy="12.078655"
+     inkscape:cx="1.78125"
+     inkscape:cy="12.03125"
      inkscape:document-units="px"
      inkscape:current-layer="layer1-9"
      showgrid="true"
-     inkscape:window-width="1319"
-     inkscape:window-height="936"
-     inkscape:window-x="472"
-     inkscape:window-y="500"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
        id="grid3947"
        empspacing="5"
        visible="true"
        enabled="true"
-       snapvisiblegridlinesonly="true" />
+       snapvisiblegridlinesonly="true"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -1209,16 +1113,6 @@
            style="display:inline"
            id="layer1-9"
            inkscape:label="Layer 1">
-          <g
-             mask="url(#mask17098)"
-             id="g7590-7"
-             style="display:inline"
-             transform="translate(0.696415,25.515546)" />
-          <g
-             mask="url(#mask17064)"
-             id="g7827-7"
-             style="display:inline"
-             transform="matrix(0.40514455,0,0,0.40514455,61.307445,630.5533)" />
           <g
              id="g4695"
              transform="translate(7.5625,-16.375)">
@@ -1310,83 +1204,9 @@
               </g>
             </g>
             <g
-               id="g17455"
-               mask="url(#mask17458)">
-              <path
-                 style="display:inline;opacity:0.75;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:2;stroke-miterlimit:4;stroke-dasharray:none;filter:url(#filter17488)"
-                 d="m 5.70269,1044.9373 c -0.185041,-0.018 -0.402396,-0.059 -0.576929,-0.1108 -0.270837,-0.079 -0.243851,0.015 -0.243851,-0.8593 0,-0.4579 0.0077,-0.7598 0.01951,-0.7646 0.01072,0 0.0317,0 0.04665,0.013 0.04847,0.037 0.294579,0.1623 0.376062,0.1926 0.186482,0.069 0.46629,0.1032 0.663393,0.083 0.436936,-0.047 0.733026,-0.2945 0.881951,-0.7389 0.120095,-0.3583 0.114052,-0.2194 0.12641,-2.9086 l 0.01137,-2.4738 0.829393,0 0.829395,0 0.0062,2.3061 c 0.0064,2.384 -5.49e-4,2.6629 -0.0777,3.0973 -0.156267,0.8809 -0.598495,1.5436 -1.254122,1.8796 -0.440731,0.2258 -1.0806,0.337 -1.637678,0.2843 z"
-                 id="path10927-5-7-9-7"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="ssscccssscccscss" />
-            </g>
-            <g
-               transform="translate(-0.888856,-1.9408198)"
-               id="g8461"
-               mask="url(#mask17030)">
-              <g
-                 id="g7590-1-0"
-                 transform="matrix(0.51237963,0,0,0.51237963,21.788022,514.89288)"
-                 style="display:inline;fill:#ffffff;stroke:#ffffff">
-                <path
-                   sodipodi:nodetypes="czczczczc"
-                   inkscape:connector-curvature="0"
-                   id="rect6501-1-6-8"
-                   d="m -16.30668,1023.0143 c 0,0 0.754772,2.7548 2.663409,4.6634 1.908637,1.9086 4.663405,2.6634 4.663405,2.6634 0,0 -2.739141,0.7391 -4.663398,2.6634 -1.924257,1.9243 -2.663409,4.6634 -2.663409,4.6634 0,0 -0.676645,-2.6766 -2.66341,-4.6634 -1.986765,-1.9868 -4.663405,-2.6634 -4.663405,-2.6634 0,0 2.801649,-0.8017 4.663405,-2.6634 1.861756,-1.8618 2.663403,-4.6634 2.663403,-4.6634 z"
-                   style="display:inline;opacity:0.85;fill:#ffffff;stroke:#ffffff;stroke-width:5.85503387;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;filter:url(#filter8410)" />
-              </g>
-            </g>
-            <g
                style="display:inline"
                id="g6432"
                transform="translate(14.061309,-9.3891741)">
-              <path
-                 style="display:inline;fill:url(#linearGradient6323-7-1-1);fill-opacity:1;stroke:none"
-                 d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-                 id="path5581-1-1"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="ccccc" />
-              <path
-                 style="display:inline;fill:url(#linearGradient5084-3-3-2-6);fill-opacity:1;stroke:none"
-                 d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-                 id="path5581-1-1-8"
-                 inkscape:connector-curvature="0"
-                 sodipodi:nodetypes="cccccc" />
-              <path
-                 inkscape:connector-curvature="0"
-                 style="display:inline;fill:url(#linearGradient5086-8-0-8-5);fill-opacity:1;stroke:none"
-                 d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-                 id="path5581-1-1-7"
-                 sodipodi:nodetypes="ccccc" />
-              <path
-                 inkscape:connector-curvature="0"
-                 style="display:inline;fill:url(#linearGradient5082-1-0-8-1);fill-opacity:1;stroke:none"
-                 d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-                 id="path5581-1-1-6-0"
-                 sodipodi:nodetypes="ccccc" />
-              <path
-                 inkscape:connector-curvature="0"
-                 style="display:inline;fill:url(#linearGradient5078-8-2-1-4);fill-opacity:1;stroke:none"
-                 d="m -7.007813,1048.62 0,5 1.4609376,-1.4844 0,-2 z"
-                 id="path5581-1-1-1-1"
-                 sodipodi:nodetypes="ccccc" />
-              <path
-                 inkscape:connector-curvature="0"
-                 style="display:inline;fill:url(#linearGradient5076-5-2-9-8);fill-opacity:1;stroke:none"
-                 d="m -5.007813,1048.62 -2,0 1.4609375,1.5156 2.0312505,0 z"
-                 id="path5581-1-1-89"
-                 sodipodi:nodetypes="ccccc" />
-              <path
-                 inkscape:connector-curvature="0"
-                 style="display:inline;fill:url(#linearGradient3500-5);fill-opacity:1;stroke:none"
-                 d="m -5.007813,1048.62 0,0 1.503907,1.5273 0,-1.5156 z"
-                 id="path5581-1-1-2"
-                 sodipodi:nodetypes="ccccc" />
-              <path
-                 inkscape:connector-curvature="0"
-                 style="display:inline;fill:url(#linearGradient5088-1-4-8-6);fill-opacity:1;stroke:none"
-                 d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-                 id="path5581-1-1-79"
-                 sodipodi:nodetypes="ccccc" />
               <g
                  style="display:inline"
                  id="g4514-8"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui.views/icons/full/elcl16/new.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui.views/icons/full/elcl16/new.svg
@@ -396,9 +396,9 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="45.254834"
-     inkscape:cx="12.562194"
-     inkscape:cy="6.5738834"
+     inkscape:zoom="32"
+     inkscape:cx="7.546875"
+     inkscape:cy="7.109375"
      inkscape:document-units="px"
      inkscape:current-layer="layer1-8"
      showgrid="true"
@@ -473,14 +473,6 @@
            id="rect3997-9-9"
            d="m 2.500702,1041.8621 12.883511,0 0,2.0053 -12.883511,0 z"
            style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-        <g
-           transform="translate(-12.593765,20.531347)"
-           style="display:inline"
-           id="g7590-7" />
-        <g
-           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
-           style="display:inline"
-           id="g7827-7" />
         <path
            transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
            sodipodi:nodetypes="cc"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui/icons/full/etool16/new_wiz.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui/icons/full/etool16/new_wiz.svg
@@ -402,11 +402,11 @@
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="1208"
-     inkscape:window-height="913"
-     inkscape:window-x="694"
-     inkscape:window-y="60"
-     inkscape:window-maximized="0"
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
      showguides="true"
      inkscape:guide-bbox="true"
      inkscape:snap-global="false"
@@ -473,14 +473,6 @@
            id="rect3997-9-9"
            d="m 2.500702,1041.8621 12.883511,0 0,2.0053 -12.883511,0 z"
            style="fill:#58b6e8;fill-opacity:1;stroke:url(#linearGradient4063-8);stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-opacity:1;stroke-dashoffset:0;display:inline" />
-        <g
-           transform="translate(-12.593765,20.531347)"
-           style="display:inline"
-           id="g7590-7" />
-        <g
-           transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
-           style="display:inline"
-           id="g7827-7" />
         <path
            transform="matrix(0.40514455,0,0,0.40514455,48.017265,625.5691)"
            sodipodi:nodetypes="cc"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui/icons/full/etool16/save_edit.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui/icons/full/etool16/save_edit.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="save_edit.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="save_edit.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -147,22 +147,31 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="32"
-     inkscape:cx="4.7239926"
-     inkscape:cy="5.7103589"
+     inkscape:cx="4.734375"
+     inkscape:cy="5.703125"
      inkscape:document-units="px"
      inkscape:current-layer="layer1"
      showgrid="true"
      inkscape:window-width="1458"
-     inkscape:window-height="1228"
-     inkscape:window-x="1055"
-     inkscape:window-y="238"
+     inkscape:window-height="1033"
+     inkscape:window-x="444"
+     inkscape:window-y="0"
      inkscape:window-maximized="0"
      showguides="true"
      inkscape:guide-bbox="true"
-     inkscape:snap-global="false">
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid3952" />
+       id="grid3952"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -182,9 +191,6 @@
      id="layer1"
      style="display:inline"
      transform="translate(0,-1036.3622)">
-    <g
-       id="g4990"
-       transform="translate(-36.649179,0.40625)" />
     <rect
        style="fill:url(#base-fill-inst);fill-opacity:1;stroke:url(#base-stroke-inst);stroke-opacity:1"
        id="disk-base"

--- a/org.eclipse.images/eclipse-svg/org.eclipse.ui/icons/full/eview16/new_persp.svg
+++ b/org.eclipse.images/eclipse-svg/org.eclipse.ui/icons/full/eview16/new_persp.svg
@@ -2,20 +2,20 @@
 <!-- Created with Inkscape (http://www.inkscape.org/) -->
 
 <svg
-   xmlns:dc="http://purl.org/dc/elements/1.1/"
-   xmlns:cc="http://creativecommons.org/ns#"
-   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
-   xmlns:svg="http://www.w3.org/2000/svg"
-   xmlns="http://www.w3.org/2000/svg"
-   xmlns:xlink="http://www.w3.org/1999/xlink"
-   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
-   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
    width="16"
    height="16"
    id="svg2"
    version="1.1"
-   inkscape:version="0.91 r13725"
-   sodipodi:docname="new_persp.svg">
+   inkscape:version="1.3.2 (091e20e, 2023-11-25, custom)"
+   sodipodi:docname="new_persp.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:dc="http://purl.org/dc/elements/1.1/">
   <defs
      id="defs4">
     <linearGradient
@@ -446,16 +446,6 @@
          style="stop-color:#ffd680;stop-opacity:1" />
     </linearGradient>
     <linearGradient
-       y2="6.9843998"
-       x2="10.007812"
-       y1="5"
-       x1="10"
-       gradientTransform="translate(-15.015625,1046.6356)"
-       gradientUnits="userSpaceOnUse"
-       id="linearGradient6323-7-1"
-       xlink:href="#linearGradient5068-6-9-4"
-       inkscape:collect="always" />
-    <linearGradient
        id="linearGradient5068-6-9-4"
        inkscape:collect="always">
       <stop
@@ -470,71 +460,11 @@
     <linearGradient
        gradientTransform="translate(-15.015625,10.2734)"
        gradientUnits="userSpaceOnUse"
-       y2="1045.3466"
-       x2="12"
-       y1="1043.3622"
-       x1="12"
-       id="linearGradient5084-3-3-2"
-       xlink:href="#linearGradient5068-6-9-4"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="15.007812"
-       y1="1043.3622"
-       x1="13"
-       id="linearGradient5086-8-0-8"
-       xlink:href="#linearGradient5068-6-9-4"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1042.3622"
-       x2="10.007812"
-       y1="1042.3622"
-       x1="12"
-       id="linearGradient5082-1-0-8"
-       xlink:href="#linearGradient5068-6-9-4"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1041.3466"
-       x2="8.0078125"
-       y1="1041.3622"
-       x1="10"
-       id="linearGradient5078-8-2-1"
-       xlink:href="#linearGradient5068-6-9-4"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1039.0497"
-       x2="10"
-       y1="1040.0653"
-       x1="10.117188"
-       id="linearGradient5076-5-2-9"
-       xlink:href="#linearGradient5068-6-9-4"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
        y2="1038.3466"
        x2="10.007812"
        y1="1038.3622"
        x1="12"
        id="linearGradient5074-2-1-3"
-       xlink:href="#linearGradient5068-6-9-4"
-       inkscape:collect="always" />
-    <linearGradient
-       gradientTransform="translate(-15.015625,10.2734)"
-       gradientUnits="userSpaceOnUse"
-       y2="1043.3466"
-       x2="14"
-       y1="1041.3622"
-       x1="14"
-       id="linearGradient5088-1-4-8"
        xlink:href="#linearGradient5068-6-9-4"
        inkscape:collect="always" />
     <radialGradient
@@ -588,21 +518,30 @@
      borderopacity="1.0"
      inkscape:pageopacity="0"
      inkscape:pageshadow="2"
-     inkscape:zoom="11.313709"
-     inkscape:cx="6.8957607"
-     inkscape:cy="8.3057891"
+     inkscape:zoom="32.000001"
+     inkscape:cx="5.3906248"
+     inkscape:cy="8.9218746"
      inkscape:document-units="px"
-     inkscape:current-layer="g6432"
+     inkscape:current-layer="layer1"
      showgrid="true"
-     inkscape:window-width="695"
-     inkscape:window-height="468"
-     inkscape:window-x="1188"
-     inkscape:window-y="606"
-     inkscape:window-maximized="0"
-     inkscape:snap-global="false">
+     inkscape:window-width="1920"
+     inkscape:window-height="991"
+     inkscape:window-x="-9"
+     inkscape:window-y="-9"
+     inkscape:window-maximized="1"
+     inkscape:snap-global="false"
+     inkscape:showpageshadow="2"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1">
     <inkscape:grid
        type="xygrid"
-       id="grid4759" />
+       id="grid4759"
+       originx="0"
+       originy="0"
+       spacingy="1"
+       spacingx="1"
+       units="px"
+       visible="true" />
   </sodipodi:namedview>
   <metadata
      id="metadata7">
@@ -612,7 +551,7 @@
         <dc:format>image/svg+xml</dc:format>
         <dc:type
            rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
-        <dc:title></dc:title>
+        <dc:title />
       </cc:Work>
     </rdf:RDF>
   </metadata>
@@ -703,10 +642,6 @@
          style="fill:url(#linearGradient8703);fill-opacity:1;stroke:none" />
     </g>
     <g
-       transform="translate(-20.000002,2.6171874e-6)"
-       style="stroke:#694337;stroke-opacity:1;display:inline"
-       id="g11029" />
-    <g
        id="g4761"
        transform="matrix(0.90974503,0,0,0.90974503,0.94380764,95.200178)">
       <g
@@ -790,48 +725,6 @@
            style="display:inline"
            id="g6432"
            transform="matrix(1.0992091,0,0,1.0992091,14.12881,-115.43836)">
-          <path
-             style="fill:url(#linearGradient6323-7-1);fill-opacity:1;stroke:none;display:inline"
-             d="m -7.007813,1053.62 2,0 1.492188,-1.4844 -2.0312504,0 z"
-             id="path5581-1-1"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             style="fill:url(#linearGradient5084-3-3-2);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1055.62 4,0 0,-1 -0.476562,-0.4844 -2.03125,0 z"
-             id="path5581-1-1-8"
-             inkscape:connector-curvature="0"
-             sodipodi:nodetypes="cccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5086-8-0-8);fill-opacity:1;stroke:none;display:inline"
-             d="m -1.484375,1052.1356 0,2 0.476562,0.4844 0,-2 z"
-             id="path5581-1-1-7"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5082-1-0-8);fill-opacity:1;stroke:none;display:inline"
-             d="m -5.007813,1053.62 0,2 1.492188,-1.4844 0,-2 z"
-             id="path5581-1-1-6"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="display:inline;fill:url(#linearGradient5078-8-2-1);fill-opacity:1;stroke:none"
-             d="m -7.007813,1049.62 0,4 1.4609376,-1.4844 0.15625,-1.8281 z"
-             id="path5581-1-1-1"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="display:inline;fill:url(#linearGradient5076-5-2-9);fill-opacity:1;stroke:none"
-             d="m -5.007813,1049.6512 -1.9023438,0.01 1.5241078,0.6485 1.511049,-0.1407 z"
-             id="path5581-1-1-89"
-             sodipodi:nodetypes="ccccc" />
-          <path
-             inkscape:connector-curvature="0"
-             style="fill:url(#linearGradient5088-1-4-8);fill-opacity:1;stroke:none;display:inline"
-             d="m -1.011718,1052.1356 -0.472657,0 0.476563,0.4844 -0.0039,0 z"
-             id="path5581-1-1-79"
-             sodipodi:nodetypes="ccccc" />
           <g
              style="display:inline"
              id="g4514"


### PR DESCRIPTION
This PR fixes some icons related to the problems described in this issue [issue](https://github.com/eclipse-platform/eclipse.platform.images/issues/104).

I only deleted white filters and empty groups. Apparently empty groups in SVGs cause bugs when combined with SVG filter elements. I reported the [issue](https://github.com/weisJ/jsvg/issues/97) to JSVG and it will soon be fixed. Until then we need to clean up the SVGs. 