### PR TITLE
Align parent group id

### DIFF
--- a/org.eclipse.images.renderer/pom.xml
+++ b/org.eclipse.images.renderer/pom.xml
@@ -15,17 +15,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
 	<modelVersion>4.0.0</modelVersion>
-	<groupId>org.eclipse.images</groupId>
-	<artifactId>org.eclipse.images.renderer</artifactId>
-	<version>1.0.100-SNAPSHOT</version>
-	<name>Eclipse Images SVG Renderer Plugin</name>
 	<parent>
 		<artifactId>org.eclipse.images.parent</artifactId>
-		<groupId>eclipse.images</groupId>
+		<groupId>org.eclipse.images</groupId>
 		<version>4.36.0-SNAPSHOT</version>
-		<relativePath>../</relativePath>
 	</parent>
+	<name>Eclipse Images SVG Renderer Plugin</name>
 	<packaging>maven-plugin</packaging>
+	<artifactId>org.eclipse.images.renderer</artifactId>
+	<version>1.0.100-SNAPSHOT</version>
 	<properties>
 		<maven-plugin-version>3.15.1</maven-plugin-version>
 		<maven-version>3.9.9</maven-version>

--- a/org.eclipse.images/pom.xml
+++ b/org.eclipse.images/pom.xml
@@ -15,12 +15,10 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
+		<groupId>org.eclipse.images</groupId>
 		<artifactId>org.eclipse.images.parent</artifactId>
-		<groupId>eclipse.images</groupId>
 		<version>4.36.0-SNAPSHOT</version>
-		<relativePath>../</relativePath>
 	</parent>
-	<groupId>org.eclipse.images</groupId>
 	<artifactId>org.eclipse.images</artifactId>
 	<version>1.0.0-SNAPSHOT</version>
 	<packaging>jar</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
 
-  <groupId>eclipse.images</groupId>
+  <groupId>org.eclipse.images</groupId>
   <artifactId>org.eclipse.images.parent</artifactId>
   <version>4.36.0-SNAPSHOT</version>
   <packaging>pom</packaging>


### PR DESCRIPTION
Currently the parent uses eclipse.images as its group id, while the childs use ord.eclipse.images.

This aligns the parent group id with the childs making it redundant to specify a groupid there again and making it more consistent, also removing the relative path as it is the default.