### PR TITLE
Adapt readme with information about this repository being archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,22 @@
-# This Repository
-This repository contains icons to be used in eclipse platform.
+# This Repository - Archived
 
-This repo stores each icon as a Scalable Vector Graphics (SVG) so it is possible to create multiple versions of the icons in different resolutions.
+This repository contains icons that are used in Eclipse Platform projects.
+It stores each icon as a Scalable Vector Graphics (SVG) so it is possible to create multiple versions of the icons in different resolutions.
+This was useful until Eclipse SWT had support for runtime processing of SVG files with the 2025-06 release.
+With the release, the SVG versions of the icons inside this repository have been added to the bundles in which they are used, which made this repository obsolete.
+Note that the state of the icons in this repository is not completely identical to icons in the Eclipse release 2025-06 and before.
 
 This repo also contains a Maven-Mojo for the generation of PNGs out of SVG (See https://github.com/eclipse-platform/eclipse.platform.images/blob/master/org.eclipse.images.renderer/src/main/java/org/eclipse/images/renderer/RenderMojo.java).
 Another Maven-Mojo also generated galleries to review the icon set on light and dark background (See https://github.com/eclipse-platform/eclipse.platform.images/blob/master/org.eclipse.images.renderer/src/main/java/org/eclipse/images/renderer/GalleryMojo.java).
 
-# What to consider when creating new SVGs
+# How to Find Icons to (Re-)Use
+
+Icons that may be reused or used as a starting point for new icons can be found in the bundles of the Eclipse Platform projects.
+One way to browse the icons of an Eclipse installation is to use the [Plug-In Image Browser](https://help.eclipse.org/latest/index.jsp?topic=%2Forg.eclipse.pde.doc.user%2Fguide%2Ftools%2Fviews%2Fimage_browser_view.htm) view.
+Finally, this repository also remains as an archive and can thus be used for browsing existing icons, they may just not be up to date.
+
+# What to Consider When Creating New SVGs
+
 The "UI Graphics" chapter of the [Eclipse User Interface Guidelines](https://eclipse-platform.github.io/ui-best-practices) gives some advice about the stylistic as well as the implementation aspects of graphics used in eclipse based tools.
 
 In the chapter "Icons Size & Placement" of the guideline states that object type icons should be 15x15 pixels big at max inside the 16x16 canvas. When drawing an object type icon keep in mind that object type icons will get "decorated" e.g. with the "inactive" and the "locked" decorator.


### PR DESCRIPTION
The SVG files inside this repository have been embedded into the Eclipse platform and and other bundles and their rasterized versions are not required anymore due to runtime support for SVGs added to Eclipse SWT.

To avoid maintenance of icon sources at multiple places, this repository is supposed to be archived. In order to document the archiving and the places to find and browse the icons now, this change adapts the readme accordingly.

Contributes to 
- https://github.com/eclipse-platform/eclipse.platform.images/issues/152

## Feedback Required

It would be great to get feedback to this and the related proposal https://github.com/eclipse-platform/eclipse.platform.images/issues/152.

In case we agree on the step of archiving this repository, we can merge this PR and I will request to mark this repository as public archive.

Closes https://github.com/eclipse-platform/eclipse.platform.images/pull/143

Closes https://github.com/eclipse-platform/eclipse.platform.images/pull/142